### PR TITLE
Change toolchain paths in GKCommon's makefile

### DIFF
--- a/projects/GKCommon/Makefile
+++ b/projects/GKCommon/Makefile
@@ -332,10 +332,10 @@ $(outdir)$(project)$(projectext): $(resources) buildcs
 .PHONY: buildcs
 buildcs: $(sources)
 ifeq ($(windows), $(softwareplatform))
-	"$(compiler)" //out:$(outdirdos)$(project)$(projectext) $(compilerflags) "Externals\\SingleInstancing\\Global Delegates.cs" $^
+	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) "Externals\\SingleInstancing\\Global Delegates.cs" $^
 else
 	@echo "Not yet implemented"
 endif
 
 $(objdir)%.resources: %.resx
-	"$(rc)" $(rcflags) //compile $<,$@
+	$(rc) $(rcflags) //compile $<,$@

--- a/projects/windows.mk
+++ b/projects/windows.mk
@@ -1,9 +1,9 @@
 ﻿# C# Compiler settings for Windows.
 
-windowscompilerdosany := C:\Program Files (x86)\MSBuild\14.0\bin\csc.exe
+windowscompilerdosany := /c/Program\ Files\ \(x86\)/MSBuild/14.0/bin/csc.exe
 windowscompilerdosx86-64 := $(windowscompilerdosany)
 windowscompilerdosx86 := $(windowscompilerdosany)
-windowsrcdosany := C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools\resgen.exe
+windowsrcdosany := /c/Program\ Files\ \(x86\)/Microsoft\ SDKs/Windows/v10.0A/bin/NETFX\ 4.6\ Tools/ResGen.exe
 windowsrcdosx86-64 := $(windowsrcdosany)
 windowsrcdosx86 := $(windowsrcdosany)
 


### PR DESCRIPTION
Paths to C# compiler and resource compiler now defined in Linux style.
The makefile doesn't use double quotes anymore when invoke the tools.

See also: #5