### PR TITLE
Change sizing of the main window on its creating

### DIFF
--- a/projects/GEDKeeper2/GKUI/MainWin.cs
+++ b/projects/GEDKeeper2/GKUI/MainWin.cs
@@ -160,8 +160,8 @@ namespace GKUI
             if (this.fOptions.MWinRect.Left != -1 && this.fOptions.MWinRect.Top != -1 && this.fOptions.MWinRect.Right != -1 && this.fOptions.MWinRect.Bottom != -1) {
                 base.Left = this.fOptions.MWinRect.Left;
                 base.Top = this.fOptions.MWinRect.Top;
-                base.Width = this.fOptions.MWinRect.Right;
-                base.Height = this.fOptions.MWinRect.Bottom;
+                base.Width = this.fOptions.MWinRect.Right - this.fOptions.MWinRect.Left + 1;
+                base.Height = this.fOptions.MWinRect.Bottom - this.fOptions.MWinRect.Top + 1;
             } else {
                 base.Left = (Screen.PrimaryScreen.WorkingArea.Width - 800) / 2;
                 base.Top = (Screen.PrimaryScreen.WorkingArea.Height - 600) / 2;


### PR DESCRIPTION
I had errors on sizing of the main window on my two Windows 10 PCs. The
window got bigger and bigger every time I had launched the application.

We (I and Serg-Norseman) thought that was a Windows 10 specific error.
But now I don't think so. Antway, I have fixed it.

Resolves: #13