### PR TITLE
Reformat CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-## GEDKeeper contributors
+﻿## GEDKeeper contributors
 
 * **[Serg V. Zhdanovskih](https://github.com/Serg-Norseman)**
 
@@ -13,7 +13,7 @@
 
 ## External components
 
-
+```
 Arbor
     https://github.com/samizdatco/arbor
     (C) 2011 Samizdat Drafting Co.
@@ -116,3 +116,4 @@ ZipStorer
     https://zipstorer.codeplex.com
     https://github.com/jaime-olivares/zipstorer
     Licensed under The MIT License (MIT).
+```


### PR DESCRIPTION
This pull is about this message: https://github.com/Serg-Norseman/GEDKeeper/commit/1524658228ea96ee8c5ac0c62036af41d6107ff7#commitcomment-17461626

We can't actually do what you want. I mean the only way to add padding to a paragraph in Markdown is to format it as *a block of code*. This preserves text formatting as is **but** obviously forces font of the text to be `monospaced`.

Markdown allows us to use inline HTML tags but it completely ignores `style` attributes in such tags. Therefore, we can't add padding with `style` attribute.

So, here in this pull, it is the only I could made for you.

I also didn't change text in "GEDKeeper contributors" section. Does it look like you want?