### PR TITLE
Add missed files into makefiles

### DIFF
--- a/projects/GEDKeeper2/Makefile
+++ b/projects/GEDKeeper2/Makefile
@@ -57,6 +57,7 @@ sources := \
 ./GKCore/GKData.cs \
 ./GKCore/GKUtils.cs \
 ./GKCore/Kinships/KinshipRec.cs \
+./GKCore/Kinships/KinshipsGraph.cs \
 ./GKCore/Kinships/KinshipsMan.cs \
 ./GKCore/LangMan.cs \
 ./GKCore/Lists/CommunicationListMan.cs \
@@ -178,6 +179,8 @@ sources := \
 ./GKUI/Dialogs/ProgressDlg.Designer.cs \
 ./GKUI/Dialogs/RecordSelectDlg.cs \
 ./GKUI/Dialogs/RecordSelectDlg.Designer.cs \
+./GKUI/Dialogs/RelationshipCalculatorDlg.cs \
+./GKUI/Dialogs/RelationshipCalculatorDlg.Designer.cs \
 ./GKUI/Dialogs/RepositoryEditDlg.cs \
 ./GKUI/Dialogs/RepositoryEditDlg.Designer.cs \
 ./GKUI/Dialogs/ResearchEditDlg.cs \
@@ -248,6 +251,7 @@ sources := \
 ./GKCore/GKData.cs \
 ./GKCore/GKUtils.cs \
 ./GKCore/Kinships/KinshipRec.cs \
+./GKCore/Kinships/KinshipsGraph.cs \
 ./GKCore/Kinships/KinshipsMan.cs \
 ./GKCore/LangMan.cs \
 ./GKCore/Lists/CommunicationListMan.cs \
@@ -369,6 +373,8 @@ sources := \
 ./GKUI/Dialogs/ProgressDlg.Designer.cs \
 ./GKUI/Dialogs/RecordSelectDlg.cs \
 ./GKUI/Dialogs/RecordSelectDlg.Designer.cs \
+./GKUI/Dialogs/RelationshipCalculatorDlg.cs \
+./GKUI/Dialogs/RelationshipCalculatorDlg.Designer.cs \
 ./GKUI/Dialogs/RepositoryEditDlg.cs \
 ./GKUI/Dialogs/RepositoryEditDlg.Designer.cs \
 ./GKUI/Dialogs/ResearchEditDlg.cs \

--- a/projects/windows.mk
+++ b/projects/windows.mk
@@ -35,5 +35,5 @@ coreresgenrefdotnet20 := \
 //r:"$(refsdos)System.Xml.dll"
 
 #analysisreleaseruleset := "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Team Tools\\Static Analysis Tools\\Rule Sets\\MinimumRecommendedRules.ruleset"
-analysisreleaseruleset := ..\\gk21.ruleset
-analysisdebugruleset := ..\\gk21.ruleset
+analysisreleaseruleset := ..\\gk2rules.ruleset
+analysisdebugruleset := ..\\gk2rules.ruleset


### PR DESCRIPTION
2016-09-19 Ruslan Garipov <brigadir15@gmail.com>

  * projects/GEDKeeper2/Makefile b/projects/GEDKeeper2/Makefile: Add missed files.
  * projects/windows.mk: Fix names of the rules-set files.

Signed-off-by: Ruslan Garipov <brigadir15@gmail.com>