### PR TITLE
Add namespaces to filenames of compiled resources

### DIFF
--- a/projects/GEDKeeper2/Makefile
+++ b/projects/GEDKeeper2/Makefile
@@ -8,20 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gedkeeper2)
 projectext := .exe
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-. \
-./GKUI \
-./GKUI/Charts \
-./GKUI/Controls \
-./GKUI/Dialogs
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GEDKeeper2.mswin.csproj
+else
+  vsproj := GEDKeeper2.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -33,6 +30,7 @@ ifeq ($(windows), $(softwareplatform))
 
 # `$(sources)` for `$(windows)`
 sources := \
+./Externals/MdiChildFormEx.cs \
 ./Externals/RusDeclension.cs \
 ./Externals/SingleInstancing/GlobalMutexPool.cs \
 ./Externals/SingleInstancing/IpcBroadcast.cs \
@@ -78,14 +76,10 @@ sources := \
 ./GKCore/Maps/GMapPoint.cs \
 ./GKCore/NamesTable.cs \
 ./GKCore/NavigationStack.cs \
+./GKCore/Operations/ChangeTracker.cs \
 ./GKCore/Operations/CustomOperation.cs \
-./GKCore/Operations/FamilyAttachSpouse.cs \
-./GKCore/Operations/FamilyDetachSpouse.cs \
-./GKCore/Operations/PersonAttachParents.cs \
-./GKCore/Operations/PersonBookmarkChange.cs \
-./GKCore/Operations/PersonDetachParents.cs \
-./GKCore/Operations/PersonPatriarchChange.cs \
-./GKCore/Operations/PersonSexChange.cs \
+./GKCore/Operations/OrdinaryOperation.cs \
+./GKCore/Operations/UndoManager.cs \
 ./GKCore/Options/AncestorsCircleOptions.cs \
 ./GKCore/Options/GlobalOptions.cs \
 ./GKCore/Options/LangRecord.cs \
@@ -103,7 +97,6 @@ sources := \
 ./GKCore/SysUtils.cs \
 ./GKCore/Tools/PlaceObj.cs \
 ./GKCore/Tools/TreeTools.cs \
-./GKCore/UndoManager.cs \
 ./GKProgram.cs \
 ./GKResources.Designer.cs \
 ./GKUI/BaseWin.cs \
@@ -150,6 +143,7 @@ sources := \
 ./GKUI/Dialogs/CommunicationEditDlg.Designer.cs \
 ./GKUI/Dialogs/DayTipsDlg.cs \
 ./GKUI/Dialogs/DayTipsDlg.Designer.cs \
+./GKUI/Dialogs/EditorDialog.cs \
 ./GKUI/Dialogs/EventEditDlg.cs \
 ./GKUI/Dialogs/EventEditDlg.Designer.cs \
 ./GKUI/Dialogs/FamilyEditDlg.cs \
@@ -232,6 +226,7 @@ else
 
 # `$(sources)` for `$(linux)`
 sources := \
+./Externals/MdiChildFormEx.cs \
 ./Externals/RusDeclension.cs \
 ./Externals/SingleInstancing/GlobalMutexPool.cs \
 ./Externals/SingleInstancing/IpcBroadcast.cs \
@@ -277,14 +272,10 @@ sources := \
 ./GKCore/Maps/GMapPoint.cs \
 ./GKCore/NamesTable.cs \
 ./GKCore/NavigationStack.cs \
+./GKCore/Operations/ChangeTracker.cs \
 ./GKCore/Operations/CustomOperation.cs \
-./GKCore/Operations/FamilyAttachSpouse.cs \
-./GKCore/Operations/FamilyDetachSpouse.cs \
-./GKCore/Operations/PersonAttachParents.cs \
-./GKCore/Operations/PersonBookmarkChange.cs \
-./GKCore/Operations/PersonDetachParents.cs \
-./GKCore/Operations/PersonPatriarchChange.cs \
-./GKCore/Operations/PersonSexChange.cs \
+./GKCore/Operations/OrdinaryOperation.cs \
+./GKCore/Operations/UndoManager.cs \
 ./GKCore/Options/AncestorsCircleOptions.cs \
 ./GKCore/Options/GlobalOptions.cs \
 ./GKCore/Options/LangRecord.cs \
@@ -302,7 +293,6 @@ sources := \
 ./GKCore/SysUtils.cs \
 ./GKCore/Tools/PlaceObj.cs \
 ./GKCore/Tools/TreeTools.cs \
-./GKCore/UndoManager.cs \
 ./GKProgram.cs \
 ./GKResources.Designer.cs \
 ./GKUI/BaseWin.cs \
@@ -349,6 +339,7 @@ sources := \
 ./GKUI/Dialogs/CommunicationEditDlg.Designer.cs \
 ./GKUI/Dialogs/DayTipsDlg.cs \
 ./GKUI/Dialogs/DayTipsDlg.Designer.cs \
+./GKUI/Dialogs/EditorDialog.cs \
 ./GKUI/Dialogs/EventEditDlg.cs \
 ./GKUI/Dialogs/EventEditDlg.Designer.cs \
 ./GKUI/Dialogs/FamilyEditDlg.cs \
@@ -432,62 +423,62 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GEDKeeper2.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GEDKeeper2.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GEDKeeper2.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GEDKeeper2.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
 # `$(resources)` for `$(windows)`
 resources := \
 $(addprefix $(objdir), \
-AboutDlg.resources \
-ACOptionsControl.resources \
-AddressEditDlg.resources \
-AssociationEditDlg.resources \
-BaseWin.resources \
-CircleChartWin.resources \
-CommonFilterDlg.resources \
-CommunicationEditDlg.resources \
-DayTipsDlg.resources \
-EventEditDlg.resources \
-FamilyEditDlg.resources \
-FilePropertiesDlg.resources \
-GKInputBox.resources \
-GKMergeControl.resources \
 GKResources.resources \
-GroupEditDlg.resources \
-LanguageSelectDlg.resources \
-LocationEditDlg.resources \
-MainWin.resources \
-MapsViewerWin.resources \
-MediaEditDlg.resources \
-MediaViewerWin.resources \
-NameEditDlg.resources \
-NoteEditDlg.resources \
-OptionsDlg.resources \
-OrganizerWin.resources \
-PatriarchsViewerWin.resources \
-PersonalNameEditDlg.resources \
-PersonEditDlg.resources \
-PersonNewDlg.resources \
-PersonsFilterDlg.resources \
-PortraitSelectDlg.resources \
-ProgressDlg.resources \
-RecordSelectDlg.resources \
-RelationshipCalculatorDlg.resources \
-RepositoryEditDlg.resources \
-ResearchEditDlg.resources \
-ScriptEditWin.resources \
-SexCheckDlg.resources \
-SlideshowWin.resources \
-SourceCitEditDlg.resources \
-SourceEditDlg.resources \
-StatisticsWin.resources \
-TaskEditDlg.resources \
-TreeChartWin.resources \
-TreeFilterDlg.resources \
-TreeToolsWin.resources \
-UserRefEditDlg.resources \
+GKUI.BaseWin.resources \
+GKUI.Charts.ACOptionsControl.resources \
+GKUI.CircleChartWin.resources \
+GKUI.Controls.GKInputBox.resources \
+GKUI.Controls.GKMergeControl.resources \
+GKUI.Dialogs.AboutDlg.resources \
+GKUI.Dialogs.AddressEditDlg.resources \
+GKUI.Dialogs.AssociationEditDlg.resources \
+GKUI.Dialogs.CommonFilterDlg.resources \
+GKUI.Dialogs.CommunicationEditDlg.resources \
+GKUI.Dialogs.DayTipsDlg.resources \
+GKUI.Dialogs.EventEditDlg.resources \
+GKUI.Dialogs.FamilyEditDlg.resources \
+GKUI.Dialogs.FilePropertiesDlg.resources \
+GKUI.Dialogs.GroupEditDlg.resources \
+GKUI.Dialogs.LanguageSelectDlg.resources \
+GKUI.Dialogs.LocationEditDlg.resources \
+GKUI.Dialogs.MediaEditDlg.resources \
+GKUI.Dialogs.NameEditDlg.resources \
+GKUI.Dialogs.NoteEditDlg.resources \
+GKUI.Dialogs.OptionsDlg.resources \
+GKUI.Dialogs.PersonalNameEditDlg.resources \
+GKUI.Dialogs.PersonEditDlg.resources \
+GKUI.Dialogs.PersonNewDlg.resources \
+GKUI.Dialogs.PersonsFilterDlg.resources \
+GKUI.Dialogs.PortraitSelectDlg.resources \
+GKUI.Dialogs.ProgressDlg.resources \
+GKUI.Dialogs.RecordSelectDlg.resources \
+GKUI.Dialogs.RelationshipCalculatorDlg.resources \
+GKUI.Dialogs.RepositoryEditDlg.resources \
+GKUI.Dialogs.ResearchEditDlg.resources \
+GKUI.Dialogs.SexCheckDlg.resources \
+GKUI.Dialogs.SourceCitEditDlg.resources \
+GKUI.Dialogs.SourceEditDlg.resources \
+GKUI.Dialogs.TaskEditDlg.resources \
+GKUI.Dialogs.TreeFilterDlg.resources \
+GKUI.Dialogs.UserRefEditDlg.resources \
+GKUI.MainWin.resources \
+GKUI.MapsViewerWin.resources \
+GKUI.MediaViewerWin.resources \
+GKUI.OrganizerWin.resources \
+GKUI.PatriarchsViewerWin.resources \
+GKUI.ScriptEditWin.resources \
+GKUI.SlideshowWin.resources \
+GKUI.StatisticsWin.resources \
+GKUI.TreeChartWin.resources \
+GKUI.TreeToolsWin.resources \
 )
 
 else
@@ -495,57 +486,59 @@ else
 # `$(resources)` for `$(linux)`
 resources := \
 $(addprefix $(objdir), \
-AboutDlg.resources \
-ACOptionsControl.resources \
-AddressEditDlg.resources \
-AssociationEditDlg.resources \
-BaseWin.resources \
-CircleChartWin.resources \
-CommonFilterDlg.resources \
-CommunicationEditDlg.resources \
-DayTipsDlg.resources \
-EventEditDlg.resources \
-FamilyEditDlg.resources \
-FilePropertiesDlg.resources \
-GKInputBox.resources \
-GKMergeControl.resources \
 GKResources.resources \
-GroupEditDlg.resources \
-LanguageSelectDlg.resources \
-LocationEditDlg.resources \
-MainWin.resources \
-MapsViewerWin.resources \
-MediaEditDlg.resources \
-MediaViewerWin.resources \
-NameEditDlg.resources \
-NoteEditDlg.resources \
-OptionsDlg.resources \
-OrganizerWin.resources \
-PatriarchsViewerWin.resources \
-PersonalNameEditDlg.resources \
-PersonEditDlg.resources \
-PersonNewDlg.resources \
-PersonsFilterDlg.resources \
-PortraitSelectDlg.resources \
-ProgressDlg.resources \
-RecordSelectDlg.resources \
-RelationshipCalculatorDlg.resources \
-RepositoryEditDlg.resources \
-ResearchEditDlg.resources \
-ScriptEditWin.resources \
-SexCheckDlg.resources \
-SlideshowWin.resources \
-SourceCitEditDlg.resources \
-SourceEditDlg.resources \
-StatisticsWin.resources \
-TaskEditDlg.resources \
-TreeChartWin.resources \
-TreeFilterDlg.resources \
-TreeToolsWin.resources \
-UserRefEditDlg.resources \
+GKUI.BaseWin.resources \
+GKUI.Charts.ACOptionsControl.resources \
+GKUI.CircleChartWin.resources \
+GKUI.Controls.GKInputBox.resources \
+GKUI.Controls.GKMergeControl.resources \
+GKUI.Dialogs.AboutDlg.resources \
+GKUI.Dialogs.AddressEditDlg.resources \
+GKUI.Dialogs.AssociationEditDlg.resources \
+GKUI.Dialogs.CommonFilterDlg.resources \
+GKUI.Dialogs.CommunicationEditDlg.resources \
+GKUI.Dialogs.DayTipsDlg.resources \
+GKUI.Dialogs.EventEditDlg.resources \
+GKUI.Dialogs.FamilyEditDlg.resources \
+GKUI.Dialogs.FilePropertiesDlg.resources \
+GKUI.Dialogs.GroupEditDlg.resources \
+GKUI.Dialogs.LanguageSelectDlg.resources \
+GKUI.Dialogs.LocationEditDlg.resources \
+GKUI.Dialogs.MediaEditDlg.resources \
+GKUI.Dialogs.NameEditDlg.resources \
+GKUI.Dialogs.NoteEditDlg.resources \
+GKUI.Dialogs.OptionsDlg.resources \
+GKUI.Dialogs.PersonalNameEditDlg.resources \
+GKUI.Dialogs.PersonEditDlg.resources \
+GKUI.Dialogs.PersonNewDlg.resources \
+GKUI.Dialogs.PersonsFilterDlg.resources \
+GKUI.Dialogs.PortraitSelectDlg.resources \
+GKUI.Dialogs.ProgressDlg.resources \
+GKUI.Dialogs.RecordSelectDlg.resources \
+GKUI.Dialogs.RelationshipCalculatorDlg.resources \
+GKUI.Dialogs.RepositoryEditDlg.resources \
+GKUI.Dialogs.ResearchEditDlg.resources \
+GKUI.Dialogs.SexCheckDlg.resources \
+GKUI.Dialogs.SourceCitEditDlg.resources \
+GKUI.Dialogs.SourceEditDlg.resources \
+GKUI.Dialogs.TaskEditDlg.resources \
+GKUI.Dialogs.TreeFilterDlg.resources \
+GKUI.Dialogs.UserRefEditDlg.resources \
+GKUI.MainWin.resources \
+GKUI.MapsViewerWin.resources \
+GKUI.MediaViewerWin.resources \
+GKUI.OrganizerWin.resources \
+GKUI.PatriarchsViewerWin.resources \
+GKUI.ScriptEditWin.resources \
+GKUI.SlideshowWin.resources \
+GKUI.StatisticsWin.resources \
+GKUI.TreeChartWin.resources \
+GKUI.TreeToolsWin.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll" \
@@ -659,9 +652,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -669,12 +662,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKCommon/Makefile
+++ b/projects/GKCommon/Makefile
@@ -8,15 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gkcommon)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx GKCommon/Controls
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKCommon.mswin.csproj
+else
+  vsproj := GKCommon.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -383,16 +385,16 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKCommon.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKCommon.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKCommon.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKCommon.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
 # `$(resources)` for `$(windows)`
 resources := \
 $(addprefix $(objdir), \
-ExtResources.resources \
-SlideList.resources \
+GKCommon.Controls.ExtResources.resources \
+GKCommon.Controls.SlideList.resources \
 )
 
 else
@@ -400,11 +402,13 @@ else
 # `$(resources)` for `$(linux)`
 resources := \
 $(addprefix $(objdir), \
-ExtResources.resources \
-SlideList.resources \
+GKCommon.Controls.ExtResources.resources \
+GKCommon.Controls.SlideList.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 ifeq ($(windows), $(softwareplatform))
 # Settings for Windows.
@@ -498,9 +502,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): $(resources) $(sources)
+$(outdir)$(project)$(projectext): $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -508,9 +512,7 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)

--- a/projects/GKFlowInputPlugin/Makefile
+++ b/projects/GKFlowInputPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gkflowinputplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKFlowInputPlugin.mswin.csproj
+else
+  vsproj := GKFlowInputPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -46,8 +47,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKFlowInputPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKFlowInputPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKFlowInputPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKFlowInputPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -66,6 +67,8 @@ FlowInputDlg.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll"
@@ -167,9 +170,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -177,12 +180,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKImageViewerPlugin/Makefile
+++ b/projects/GKImageViewerPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gkimageviewerplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKImageViewerPlugin.mswin.csproj
+else
+  vsproj := GKImageViewerPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -47,8 +48,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKImageViewerPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKImageViewerPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKImageViewerPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKImageViewerPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -69,6 +70,8 @@ ImageViewerWin.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll"
@@ -170,9 +173,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -180,12 +183,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKNamesBookPlugin/Makefile
+++ b/projects/GKNamesBookPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gknamesbookplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKNamesBookPlugin.mswin.csproj
+else
+  vsproj := GKNamesBookPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -47,8 +48,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKNamesBookPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKNamesBookPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKNamesBookPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKNamesBookPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -67,6 +68,8 @@ NBResources.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll"
@@ -168,9 +171,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -178,12 +181,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKNavigatorPlugin/Makefile
+++ b/projects/GKNavigatorPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gknavigatorplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKNavigatorPlugin.mswin.csproj
+else
+  vsproj := GKNavigatorPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -46,8 +47,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKNavigatorPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKNavigatorPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKNavigatorPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKNavigatorPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -66,6 +67,8 @@ PluginForm.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll"
@@ -167,9 +170,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -177,12 +180,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKPedigreeImporterPlugin/Makefile
+++ b/projects/GKPedigreeImporterPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gkpedigreeimporterplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKPedigreeImporterPlugin.mswin.csproj
+else
+  vsproj := GKPedigreeImporterPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -50,8 +51,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKPedigreeImporterPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKPedigreeImporterPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKPedigreeImporterPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKPedigreeImporterPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -70,6 +71,8 @@ PedigreeImporterDlg.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll" \
@@ -173,9 +176,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -183,12 +186,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKSamplePlugin/Makefile
+++ b/projects/GKSamplePlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gksampleplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKSamplePlugin.mswin.csproj
+else
+  vsproj := GKSamplePlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -46,8 +47,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKSamplePlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKSamplePlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKSamplePlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKSamplePlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -66,6 +67,8 @@ PluginForm.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll"
@@ -162,9 +165,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -172,12 +175,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKTextSearchPlugin/Makefile
+++ b/projects/GKTextSearchPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gktextsearchplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKTextSearchPlugin.mswin.csproj
+else
+  vsproj := GKTextSearchPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -48,8 +49,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKTextSearchPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKTextSearchPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKTextSearchPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKTextSearchPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -68,6 +69,8 @@ TextSearchWin.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll" \
@@ -173,9 +176,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -183,12 +186,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):

--- a/projects/GKTreeVizPlugin/Makefile
+++ b/projects/GKTreeVizPlugin/Makefile
@@ -8,16 +8,17 @@ include $(includemk)toolchain.mk
 project := $(gktreevizplugin)
 projectext := .dll
 
-# Get directories list for `vpath %.resx` via (run from this directory):
-# find -regex '.+\.resx' | sed 's/\(.\+\)\/.\+/\1 \\/' | awk '!a[$0]++' | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
-vpath %.resx \
-.
-
 objdir := obj/$(releasetype)/
 objdirdos := obj\\$(releasetype)\\
 outdir := $(objdir)
 outdirdos := $(objdirdos)
 installdir := ../../plugins/
+
+ifeq ($(windows), $(softwareplatform))
+  vsproj := GKTreeVizPlugin.mswin.csproj
+else
+  vsproj := GKTreeVizPlugin.linux.csproj
+endif
 
 # Get `sources` via (run from this directory):
 # find -regex '.+\.cs' | sed 's/\(.\+\)/\1 \\/' | sort | sed -n "x;/.\+/ p;g;$ s/\(.\+\) \\\\/\1/; $ p"
@@ -54,8 +55,8 @@ endif
 # Get files list for `resources` via (run from this directory):
 # find -regex '.+\.resx' | sed 's/.\+\/\(.\+\)\.resx/\1.resources \\/' | sort
 # Or (this is more valid -- it takes data from a project file):
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKTreeVizPlugin.mswin.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
-# grep "[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>" GKTreeVizPlugin.linux.csproj | sed "y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\/|\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/" | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKTreeVizPlugin.mswin.csproj | sort
+# sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\)\.resx\"\([[:space:]]\?\/\)\?>/\1.resources \\\\/;s/\//\./g;P}" < GKTreeVizPlugin.linux.csproj | sort
 # Because `$(resources)` must (may) have different values for Windows and Linux targets.
 ifeq ($(windows), $(softwareplatform))
 
@@ -74,6 +75,8 @@ TVSettingsDlg.resources \
 )
 
 endif
+
+resdep := $(objdir)resmake.d
 
 cscrefs := \
 //reference:"..\\$(gkcommon)\\obj\\$(releasetype)\\$(gkcommon).dll" \
@@ -180,9 +183,9 @@ clean:
 $(objdir):
 	@mkdir -p $(objdir)
 
-$(resources): | $(objdir)
+$(resdep): | $(objdir)
 
-$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resources) $(sources)
+$(outdir)$(project)$(projectext): ../$(gkcommon)/obj/$(releasetype)/$(gkcommon).dll $(resdep) $(resources) $(sources)
 ifeq ($(windows), $(softwareplatform))
 	$(compiler) //out:$(outdirdos)$(project)$(projectext) $(compilerflags) $(patsubst $(objdir)%,//resource:$(objdirdos)\\%,$(resources)) $(sources)
 else
@@ -190,12 +193,10 @@ else
 endif
 	@echo "**** $(project)$(projectext): build completed ($(releasetype) for $(hardwareplatform), $(softwareplatform))."
 
-$(objdir)%.resources: %.resx
-ifeq ($(windows), $(softwareplatform))
-	$(rc) $(rcflags) //compile $<,$@
-else
-	@echo "rc: not yet implemented for $(linux)"
-endif
+$(resdep): $(vsproj)
+	sed -n -e "/[[:space:]]\+<EmbeddedResource[[:space:]]\+Include=\".*\"\([[:space:]]\?\/\)\?>/ {y/\\\\/\//;s/[[:space:]]\\+<EmbeddedResource[[:space:]]\+Include=.*[\"]\(.*\.resx\)\"\([[:space:]]\?\/\)\?>/\1/;h;y/\//\./;s/\(.\+\.\)resx/$(subst /,\\/,$(objdir))\1resources/;G;s/\(.\+\)\n\(.\+\)/\1: \2\n\t$$\(rc\) $$\(rcflags\) \/\/compile $$<,$$\@/p}" < $< > $@
+
+-include $(resdep)
 
 .PHONY: $(gkcommon)
 $(gkcommon):


### PR DESCRIPTION
This commit force makefiles to use msbuild-like style when makefile
creates a compiled resource. The latter now has owner's namespace in
filename. This fixes errors when a .NET application can't find a
resource.

But there is an underside in this PR: makefiles now do depend on
VS project files (makefiles use their content).
