### PR TITLE
Keep a circle chart at center; render to a non-screen contexts

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -69,6 +69,8 @@ namespace GKUI.Charts
             }
         }
 
+        private struct ValuesAsFloat {};
+
         protected static readonly object EventRootChanged;
 
         protected const int CENTER_RAD = 90;
@@ -107,6 +109,7 @@ namespace GKUI.Charts
         /* This chart's GDI+ paths boundary (in the following order: left, top,
          * right and bottom). */
         private float[] fBounds;
+        private ValuesAsFloat fFloatType = new ValuesAsFloat();
 
         public int GenWidth
         {
@@ -244,10 +247,8 @@ namespace GKUI.Charts
                 fBounds[2] = Math.Max(fBounds[2], bound.Right);
                 fBounds[3] = Math.Max(fBounds[3], bound.Bottom);
             }
-            /* Add double width of the pen -- adjust both sides. */
-            Size pageSize = new Size((int)(fBounds[2] - fBounds[0] + (fPen.Width * 2)),
-                                     (int)(fBounds[3] - fBounds[1] + (fPen.Width * 2)));
-            AdjustViewPort(pageSize, false);
+            Size boundary = GetPathsBoundary();
+            AdjustViewPort(boundary, false);
             /* Invalidate(); */
         }
 
@@ -260,20 +261,49 @@ namespace GKUI.Charts
         }
 
         /// <summary>
+        /// Gets boundary of the area that includes all paths of this chart.
+        /// This member does not recalculates boundaries -- it uses calculation
+        /// made by member `Changed`.
+        /// Result includes width of a path's borders.
+        /// </summary>
+        /// <returns>The paths boundary.</returns>
+        private SizeF GetPathsBoundary(ValuesAsFloat dummy)
+        {
+            /* Add double width of the pen -- adjust both sides. */
+            return new SizeF(fBounds[2] - fBounds[0] + (fPen.Width * 2),
+                             fBounds[3] - fBounds[1] + (fPen.Width * 2));
+        }
+        private Size GetPathsBoundary()
+        {
+            /* Add double width of the pen -- adjust both sides. */
+            return new Size((int)(fBounds[2] - fBounds[0] + (fPen.Width * 2)),
+                            (int)(fBounds[3] - fBounds[1] + (fPen.Width * 2)));
+        }
+
+        /// <summary>
         /// Returns the center point of this chart relative to up left point of
         /// this window's client area.
+        /// According to discussion at PR #99 (GitHub), this member centers this
+        /// chart on an axis when there's no scrolling required along that axis.
+        /// And if scrolling is required, this member aligns this chart on its
+        /// left edge.
         /// </summary>
         /// <returns>Center point of this chart.</returns>
         private PointF GetCenter()
         {
             PointF center = new PointF();
-            center.X = AutoScrollPosition.X + fOffsetX;
-            center.Y = AutoScrollPosition.Y + fOffsetY;
-            if (fBounds[0] < 0) {
-                center.X -= fBounds[0];
+            SizeF boundary = GetPathsBoundary(fFloatType);
+            if (ClientSize.Width > boundary.Width) {
+                center.X = Math.Min(ClientSize.Width - fBounds[2], ClientSize.Width >> 1);
             }
-            if (fBounds[1] < 0) {
-                center.Y -= fBounds[1];
+            else {
+                center.X = AutoScrollPosition.X + fOffsetX - fBounds[0];
+            }
+            if (ClientSize.Height > boundary.Height) {
+                center.Y = Math.Min(ClientSize.Height - fBounds[3], ClientSize.Height >> 1);
+            }
+            else {
+                center.Y = AutoScrollPosition.Y + fOffsetY - fBounds[1];
             }
             return center;
         }
@@ -511,9 +541,9 @@ namespace GKUI.Charts
             PointF center = GetCenter();
             e.Graphics.TranslateTransform(center.X, center.Y);
             InternalDraw(e.Graphics);
+            e.Graphics.ResetTransform();
 
             base.OnPaint(e);
-            e.Graphics.ResetTransform();
         }
 
         protected override void OnResize(EventArgs e)


### PR DESCRIPTION
As we have previously discussed, this PR implements the following stuff:

1. When it's possible, the code now renders a circle chart on an axis center (both or single),
2. The code knows how to render a circle chart onto a (non-)screen GDI+ context. Commit 847e5b3 does not contain any printing code, but as a demonstration of possible features the code renders a circle chart into a bitmap when user double clicks on the chart window.

ChangeLog:

2017-01-31 Ruslan Garipov <brigadir15@gmail.com>

Keep a circle chart at the window center, when possible.
Render onto non-screen GDI+ contexts.
 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (ValuesAsFloat, RenderTarget):
 Added new types.
 (fFloatType, GetPathsBoundary(ValuesAsFloat), GetPathsBoundary(): Added new
 members.
 (GetCenter): Add parameter `target`.
 (GetCenterForScreenRendering, GetCenterForNonScreenRendering, Render): Added
 new members.
 (OnDoubleClick): New TEMPORARY member.
