### PR TITLE
Replace direct matrix usage with matrices product

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -557,14 +557,16 @@ namespace GKUI.Charts
                 float angle = clockwise ? startAngle - offset : startAngle + offset;
 
                 double radAngle = angle * (Math.PI / 180.0d);
-                float x = (float)(centerX + previousTransformation.OffsetX + Math.Cos(radAngle) * radius);
-                float y = (float)(centerY + previousTransformation.OffsetY - Math.Sin(radAngle) * radius);
+                float x = (float)(centerX + Math.Cos(radAngle) * radius);
+                float y = (float)(centerY - Math.Sin(radAngle) * radius);
                 float charRotation = 90 - (inside ? angle : angle + 180);
                 charRotation *= (float)(Math.PI / 180.0f);
                 float cosine = (float)(Math.Cos(charRotation));
                 float sine = (float)(Math.Sin(charRotation));
                 /* Translate and rotate. */
-                gfx.Transform = new Matrix(cosine, sine, -sine, cosine, x, y);
+                Matrix m = new Matrix(cosine, sine, -sine, cosine, x, y);
+                m.Multiply(previousTransformation, MatrixOrder.Append);
+                gfx.Transform = m;
 
                 string chr = new String(text[i], 1);
                 gfx.DrawString(chr, font, brush, 0, 0);


### PR DESCRIPTION
As I proposed by myself on GEDKeeper chat at [GITTER](https://gitter.im/Serg-Norseman/GEDKeeper), `CircleChart.DrawArcText` should use multiplication of matrices instead of **direct usage of offsets only** in the matrix `previousTransformation`. This commit implements the proposal.

ChangeLog:

2017-02-01 Ruslan Garipov <brigadir15@gmail.com>

* projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (DrawArcText): Used matrices product, not direct access to offsets **only**.
