### PR TITLE
Render circle charts with floating-point values

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs
@@ -75,12 +75,12 @@ namespace GKUI.Charts
         {
             fSegments.Clear();
 
-            int inRad = CENTER_RAD - 50;
+            float inRad = CENTER_RAD - 50;
 
             PersonSegment segment = new PersonSegment(0);
             GraphicsPath path = segment.Path;
             path.StartFigure();
-            path.AddEllipse(-inRad, -inRad, inRad << 1, inRad << 1);
+            path.AddEllipse(-inRad, -inRad, inRad * 2.0f, inRad * 2.0f);
             path.CloseFigure();
             fSegments.Add(segment);
 
@@ -88,14 +88,14 @@ namespace GKUI.Charts
             for (int gen = 1; gen <= fMaxGenerations; gen++) {
                 inRad = (CENTER_RAD - 50) + ((gen - 1) * fGenWidth);
 
-                int extRad = inRad + fGenWidth;
+                float extRad = inRad + fGenWidth;
                 maxSteps *= 2;
 
                 float stepAngle = (360.0f / maxSteps);
 
-                for (int stp = 0; stp < maxSteps; stp++)
+                for (int step = 0; step < maxSteps; step++)
                 {
-                    float ang1 = (stp * stepAngle) - 90.0f;
+                    float ang1 = (step * stepAngle) - 90.0f;
                     float ang2 = ang1 + stepAngle;
 
                     segment = new PersonSegment(gen);
@@ -127,7 +127,7 @@ namespace GKUI.Charts
             }
         }
 
-        private PersonSegment SetSegmentParams(int index, GEDCOMIndividualRecord rec, int rad, int groupIndex)
+        private PersonSegment SetSegmentParams(int index, GEDCOMIndividualRecord rec, float rad, int groupIndex)
         {
             if (index < 0 || index >= fSegments.Count) {
                 return null;
@@ -140,7 +140,7 @@ namespace GKUI.Charts
             }
         }
 
-        private PersonSegment TraverseAncestors(GEDCOMIndividualRecord iRec, float v, int gen, int rad, float ro, int prevSteps, int groupIndex)
+        private PersonSegment TraverseAncestors(GEDCOMIndividualRecord iRec, float v, int gen, float rad, float ro, int prevSteps, int groupIndex)
         {
             try
             {
@@ -155,7 +155,7 @@ namespace GKUI.Charts
                     }
                 }
 
-                int genSize = (int)Math.Pow(2.0, gen);
+                int genSize = 1 << gen;
                 float ang = (360.0f / genSize);
 
                 int idx = prevSteps + (int)(v / ang);

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -50,7 +50,7 @@ namespace GKUI.Charts
             public int Gen;
             public GEDCOMIndividualRecord IRec;
             public GraphicsPath Path;
-            public int Rad;
+            public float Rad;
             public float StartAngle;
             public float WedgeAngle;
 
@@ -79,8 +79,8 @@ namespace GKUI.Charts
 
         protected static readonly object EventRootChanged;
 
-        protected const int CENTER_RAD = 90;
-        protected const int DEFAULT_GEN_WIDTH = 60;
+        protected const float CENTER_RAD = 90;
+        protected const float DEFAULT_GEN_WIDTH = 60;
 
         protected readonly SolidBrush[] fCircleBrushes;
         protected readonly SolidBrush[] fDarkBrushes;
@@ -93,7 +93,7 @@ namespace GKUI.Charts
         /* This chart's GDI+ paths boundary (in the following order: left, top,
          * right and bottom). */
         private float[] fBounds;
-        protected int fGenWidth;
+        protected float fGenWidth;
         private string fHint;
         protected int fIndividualsCount;
         /* TODO(brigadir15@gmail.com): Member `fMaxGenerations` should be a
@@ -107,8 +107,8 @@ namespace GKUI.Charts
          * Therefore, to avoid someone's tendency to change initial values of
          * member `fMaxGenerations`, the member should be a const field. */
         protected int fMaxGenerations;
-        protected int fOffsetX = 0;
-        protected int fOffsetY = 0;
+        protected float fOffsetX = 0;
+        protected float fOffsetY = 0;
         protected Pen fPen;
         protected GEDCOMIndividualRecord fRootPerson;
         protected CircleSegment fSelected;
@@ -116,14 +116,13 @@ namespace GKUI.Charts
 
         /* Animation timer. */
         #if FUN_ANIM
-        //private float fAnimationAngle;
         private Timer fAnimationTimer;
-        #endif
         private UInt64 fAnimationTime = 0;
         private const UInt64 fAnimationTimeLimit = 17;
+        #endif
 
 
-        public int GenWidth
+        public float GenWidth
         {
             get {
                 return fGenWidth;
@@ -362,11 +361,11 @@ namespace GKUI.Charts
             return result;
         }
 
-        protected CircleSegment FindSegment(int mX, int mY)
+        protected CircleSegment FindSegment(float mX, float mY)
         {
             PointF center = GetCenter(RenderTarget.rtScreen);
-            mX -= (int)(center.X);
-            mY -= (int)(center.Y);
+            mX -= center.X;
+            mY -= center.Y;
             CircleSegment result = null;
 
             int numberOfSegments = fSegments.Count;
@@ -392,6 +391,7 @@ namespace GKUI.Charts
         {
             PointF center = GetCenter(target);
             context.TranslateTransform(center.X, center.Y);
+#if FUN_ANIM
             if (RenderTarget.rtScreen == target) {
                 context.RotateTransform((float)(3.5f * Math.Sin(fAnimationTime) *
                                                 Math.Exp(-1.0 * fAnimationTime / fAnimationTimeLimit)));
@@ -401,6 +401,7 @@ namespace GKUI.Charts
                                       (float)(Math.Exp(-1.0 * (fAnimationTime + 50.0f) / fAnimationTimeLimit)) : 0);
                 context.ScaleTransform(zoomX, zoomY);
             }
+#endif
             InternalDraw(context);
             context.ResetTransform();
         }
@@ -432,7 +433,7 @@ namespace GKUI.Charts
                 GKUtils.GetNameParts(iRec, out surn, out givn, out dummy);
             }
 
-            int rad = segment.Rad - 20;
+            float rad = segment.Rad - 20;
             float angle = segment.StartAngle + 90.0f + segment.WedgeAngle / 2;
             float wedgeAngle = segment.WedgeAngle;
 
@@ -440,10 +441,10 @@ namespace GKUI.Charts
             Matrix previousTransformation = gfx.Transform;
             if (gen == 0) {
 
-                SizeF sizeF = gfx.MeasureString(surn, Font);
-                gfx.DrawString(surn, Font, fCircleBrushes[8], -sizeF.Width / 2f, -sizeF.Height / 2f - sizeF.Height / 2f);
-                sizeF = gfx.MeasureString(givn, Font);
-                gfx.DrawString(givn, Font, fCircleBrushes[8], -sizeF.Width / 2f, 0f);
+                SizeF size = gfx.MeasureString(surn, Font);
+                gfx.DrawString(surn, Font, fCircleBrushes[8], -size.Width / 2f, -size.Height / 2f - size.Height / 2f);
+                size = gfx.MeasureString(givn, Font);
+                gfx.DrawString(givn, Font, fCircleBrushes[8], -size.Width / 2f, 0f);
 
             } else {
 
@@ -481,12 +482,12 @@ namespace GKUI.Charts
 
                         if (fOptions.ArcText) {
                             if (gen == 2) {
-                                SizeF sizeF = gfx.MeasureString(surn, Font);
-                                DrawArcText(gfx, surn, 0.0f, 0.0f, rad + sizeF.Height / 2f,
+                                SizeF size = gfx.MeasureString(surn, Font);
+                                DrawArcText(gfx, surn, 0.0f, 0.0f, rad + size.Height / 2f,
                                             segment.StartAngle, segment.WedgeAngle, true, true, Font, fCircleBrushes[8]);
 
-                                sizeF = gfx.MeasureString(givn, Font);
-                                DrawArcText(gfx, givn, 0.0f, 0.0f, rad - sizeF.Height / 2f,
+                                size = gfx.MeasureString(givn, Font);
+                                DrawArcText(gfx, givn, 0.0f, 0.0f, rad - size.Height / 2f,
                                             segment.StartAngle, segment.WedgeAngle, true, true, Font, fCircleBrushes[8]);
                             } else {
                                 DrawArcText(gfx, givn, 0.0f, 0.0f, rad,
@@ -506,27 +507,27 @@ namespace GKUI.Charts
                             Matrix m = new Matrix(cosine, sine, -sine, cosine, dx, -dy);
                             m.Multiply(previousTransformation, MatrixOrder.Append);
                             gfx.Transform = m;
-                            SizeF sizeF2 = gfx.MeasureString(surn, Font);
-                            gfx.DrawString(surn, Font, fCircleBrushes[8], -sizeF2.Width / 2f, -sizeF2.Height / 2f);
+                            SizeF size = gfx.MeasureString(surn, Font);
+                            gfx.DrawString(surn, Font, fCircleBrushes[8], -size.Width / 2f, -size.Height / 2f);
 
-                            sizeF2 = gfx.MeasureString(givn, Font);
-                            dx = (float)Math.Sin(Math.PI * angle / 180.0f) * (rad - sizeF2.Height);
-                            dy = (float)Math.Cos(Math.PI * angle / 180.0f) * (rad - sizeF2.Height);
+                            size = gfx.MeasureString(givn, Font);
+                            dx = (float)Math.Sin(Math.PI * angle / 180.0f) * (rad - size.Height);
+                            dy = (float)Math.Cos(Math.PI * angle / 180.0f) * (rad - size.Height);
                             m = new Matrix(cosine, sine, -sine, cosine, dx, -dy);
                             m.Multiply(previousTransformation, MatrixOrder.Append);
                             gfx.Transform = m;
-                            gfx.DrawString(givn, Font, fCircleBrushes[8], -sizeF2.Width / 2f, -sizeF2.Height / 2f);
+                            gfx.DrawString(givn, Font, fCircleBrushes[8], -size.Width / 2f, -size.Height / 2f);
                         }
 
                     } else if (wedgeAngle < 361) {
 
                         if (fOptions.ArcText) {
-                            SizeF sizeF = gfx.MeasureString(surn, Font);
-                            DrawArcText(gfx, surn, 0.0f, 0.0f, rad + sizeF.Height / 2f,
+                            SizeF size = gfx.MeasureString(surn, Font);
+                            DrawArcText(gfx, surn, 0.0f, 0.0f, rad + size.Height / 2f,
                                         segment.StartAngle, segment.WedgeAngle, true, true, Font, fCircleBrushes[8]);
 
-                            sizeF = gfx.MeasureString(givn, Font);
-                            DrawArcText(gfx, givn, 0.0f, 0.0f, rad - sizeF.Height / 2f,
+                            size = gfx.MeasureString(givn, Font);
+                            DrawArcText(gfx, givn, 0.0f, 0.0f, rad - size.Height / 2f,
                                         segment.StartAngle, segment.WedgeAngle, true, true, Font, fCircleBrushes[8]);
                         } else {
                             float dx = (float)Math.Sin(Math.PI * angle / 180.0f) * rad;
@@ -538,10 +539,10 @@ namespace GKUI.Charts
                             m.Multiply(previousTransformation, MatrixOrder.Append);
                             gfx.Transform = m;
 
-                            SizeF sizeF = gfx.MeasureString(surn, Font);
-                            gfx.DrawString(surn, Font, fCircleBrushes[8], -sizeF.Width / 2f, -sizeF.Height / 2f);
-                            sizeF = gfx.MeasureString(givn, Font);
-                            gfx.DrawString(givn, Font, fCircleBrushes[8], -sizeF.Width / 2f, -sizeF.Height / 2f + sizeF.Height);
+                            SizeF size = gfx.MeasureString(surn, Font);
+                            gfx.DrawString(surn, Font, fCircleBrushes[8], -size.Width / 2f, -size.Height / 2f);
+                            size = gfx.MeasureString(givn, Font);
+                            gfx.DrawString(givn, Font, fCircleBrushes[8], -size.Width / 2f, -size.Height / 2f + size.Height);
                         }
 
                     }
@@ -552,7 +553,7 @@ namespace GKUI.Charts
 
         private static bool IsNarrowSegment(Graphics gfx, string text, float radius, float wedgeAngle, Font font)
         {
-            var size = gfx.MeasureString(text, font);
+            SizeF size = gfx.MeasureString(text, font);
             radius = radius + size.Height / 2.0f;
 
             float wedgeL = radius * (float)SysUtils.DegreesToRadians(wedgeAngle);
@@ -564,7 +565,7 @@ namespace GKUI.Charts
                                         float startAngle, float wedgeAngle,
                                         bool inside, bool clockwise, Font font, Brush brush)
         {
-            var size = gfx.MeasureString(text, font);
+            SizeF size = gfx.MeasureString(text, font);
             radius = radius + size.Height / 2.0f;
 
             float textAngle = Math.Min((float)SysUtils.RadiansToDegrees((size.Width * 1.75f) / radius), wedgeAngle);

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -18,7 +18,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-//define FUN_ANIM
+// #define FUN_ANIM
 
 using System;
 using System.Collections.Generic;
@@ -606,7 +606,6 @@ namespace GKUI.Charts
         private void InitTimer()
         {
             if ((null == fAnimationTimer) || !fAnimationTimer.Enabled) {
-                fAnimationAngle = 0.0f;
                 fAnimationTime = 0;
                 fAnimationTimer = new Timer();
                 fAnimationTimer.Interval = 1;

--- a/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
@@ -214,23 +214,23 @@ namespace GKUI.Charts
                                                  float ang1, float ang2)
         {
             float angval1 = (float)(ang1 * Math.PI / 180.0f);
-            PointF point1 = new PointF(ctX + (float)(inRad * Math.Cos(angval1)),
-                                       ctY + (float)(inRad * Math.Sin(angval1)));
-            PointF point2 = new PointF(ctX + (float)(extRad * Math.Cos(angval1)),
-                                       ctY + (float)(extRad * Math.Sin(angval1)));
+            int px1 = ctX + (int)(inRad * Math.Cos(angval1));
+            int py1 = ctY + (int)(inRad * Math.Sin(angval1));
+            int px2 = ctX + (int)(extRad * Math.Cos(angval1));
+            int py2 = ctY + (int)(extRad * Math.Sin(angval1));
             float angval2 = (float)(ang2 * Math.PI / 180.0f);
-            PointF point3 = new PointF(ctX + (float)(inRad * Math.Cos(angval2)),
-                                       ctY + (float)(inRad * Math.Sin(angval2)));
-            PointF point4 = new PointF(ctX + (float)(extRad * Math.Cos(angval2)),
-                                       ctY + (float)(extRad * Math.Sin(angval2)));
+            int nx1 = ctX + (int)(inRad * Math.Cos(angval2));
+            int ny1 = ctY + (int)(inRad * Math.Sin(angval2));
+            int nx2 = ctX + (int)(extRad * Math.Cos(angval2));
+            int ny2 = ctY + (int)(extRad * Math.Sin(angval2));
 
             float ir2 = inRad * 2.0f;
             float er2 = extRad * 2.0f;
 
             path.StartFigure();
-            path.AddLine(point1, point2);
+            path.AddLine(px2, py2, px1, py1);
             if (0 < ir2) path.AddArc(ctX - inRad, ctY - inRad, ir2, ir2, ang1, wedgeAngle);
-            path.AddLine(point3, point4);
+            path.AddLine(nx1, ny1, nx2, ny2);
             path.AddArc(ctX - extRad, ctY - extRad, er2, er2, ang2, -wedgeAngle);
             path.CloseFigure();
         }

--- a/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
@@ -203,35 +203,34 @@ namespace GKUI.Charts
         #region Static drawing methods
 
         internal static void CreateCircleSegment(GraphicsPath path,
-                                                 int inRad, int extRad, float wedgeAngle,
+                                                 float inRad, float extRad, float wedgeAngle,
                                                  float ang1, float ang2)
         {
             CreateCircleSegment(path, 0, 0, inRad, extRad, wedgeAngle, ang1, ang2);
         }
 
         internal static void CreateCircleSegment(GraphicsPath path, int ctX, int ctY,
-                                                 int inRad, int extRad, float wedgeAngle,
+                                                 float inRad, float extRad, float wedgeAngle,
                                                  float ang1, float ang2)
         {
             float angval1 = (float)(ang1 * Math.PI / 180.0f);
-            int px1 = ctX + (int)(inRad * Math.Cos(angval1));
-            int py1 = ctY + (int)(inRad * Math.Sin(angval1));
-            int px2 = ctX + (int)(extRad * Math.Cos(angval1));
-            int py2 = ctY + (int)(extRad * Math.Sin(angval1));
-
+            PointF point1 = new PointF(ctX + (float)(inRad * Math.Cos(angval1)),
+                                       ctY + (float)(inRad * Math.Sin(angval1)));
+            PointF point2 = new PointF(ctX + (float)(extRad * Math.Cos(angval1)),
+                                       ctY + (float)(extRad * Math.Sin(angval1)));
             float angval2 = (float)(ang2 * Math.PI / 180.0f);
-            int nx1 = ctX + (int)(inRad * Math.Cos(angval2));
-            int ny1 = ctY + (int)(inRad * Math.Sin(angval2));
-            int nx2 = ctX + (int)(extRad * Math.Cos(angval2));
-            int ny2 = ctY + (int)(extRad * Math.Sin(angval2));
+            PointF point3 = new PointF(ctX + (float)(inRad * Math.Cos(angval2)),
+                                       ctY + (float)(inRad * Math.Sin(angval2)));
+            PointF point4 = new PointF(ctX + (float)(extRad * Math.Cos(angval2)),
+                                       ctY + (float)(extRad * Math.Sin(angval2)));
 
-            int ir2 = inRad * 2;
-            int er2 = extRad * 2;
+            float ir2 = inRad * 2.0f;
+            float er2 = extRad * 2.0f;
 
             path.StartFigure();
-            path.AddLine(px2, py2, px1, py1);
-            if (ir2 != 0) path.AddArc(ctX - inRad, ctY - inRad, ir2, ir2, ang1, wedgeAngle);
-            path.AddLine(nx1, ny1, nx2, ny2);
+            path.AddLine(point1, point2);
+            if (0 < ir2) path.AddArc(ctX - inRad, ctY - inRad, ir2, ir2, ang1, wedgeAngle);
+            path.AddLine(point3, point4);
             path.AddArc(ctX - extRad, ctY - extRad, er2, er2, ang2, -wedgeAngle);
             path.CloseFigure();
         }

--- a/projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs
@@ -60,23 +60,23 @@ namespace GKUI.Charts
             if (fRootPerson != null) {
                 rootSegment = TraverseDescendants(fRootPerson, 0);
 
-                const int inRad = CENTER_RAD - 50;
+                const float inRad = CENTER_RAD - 50;
                 float stepAngle = (360.0f / rootSegment.TotalSubSegments);
 
                 CalcDescendants(rootSegment, inRad, -90.0f, stepAngle);
             }
         }
 
-        private void CalcDescendants(PersonSegment segment, int inRad, float startAngle, float stepAngle)
+        private void CalcDescendants(PersonSegment segment, float inRad, float startAngle, float stepAngle)
         {
             GraphicsPath path = segment.Path;
 
-            int extRad;
+            float extRad;
             if (segment.Gen == 0) {
                 segment.WedgeAngle = 360.0f;
 
                 path.StartFigure();
-                path.AddEllipse(-inRad, -inRad, inRad << 1, inRad << 1);
+                path.AddEllipse(-inRad, -inRad, inRad * 2.0f, inRad * 2.0f);
                 path.CloseFigure();
 
                 extRad = inRad;


### PR DESCRIPTION
Using integer calculations being rendering on GDI+ causes precision losses. If one uses GDI+ scaling, losses increase **dramatically**. This commit replaces integer calculations on a circle chart rendering with floating-point values processing.

ChangeLog:

2017-02-02 Ruslan Garipov <brigadir15@gmail.com>

 * projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs (BuildPathTree): Replaced
 `int` with `float`.
 (SetSegmentParams): parameter `rad` got type `float`.
 (TraverseAncestors): Likewise. Optimized powering of literal `2`.
 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (CircleSegment::Rad): Change
 type to `float`. All callers changed.
 (CENTER_RAD, DEFAULT_GEN_WIDTH, fGenWidth, fOffsetX, fOffsetY, GenWidth):
 Likewise.
 (fAnimationTime, CricleChart::fAnimationTimeLimit) [FUN_ANIM]: Moved into the
 if-defined guard.
 (FindSegment): Changed type of the function parameters to `float`. All callers
 changed.
 * projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
 (CreateCircleSegment(GraphicsPath, int, int, float, float,
 float)): Changed type of parameters `inRad` and `extRad` to `float`. All
 callers changed.
 (CreateCircleSegment(GraphicsPath, int, int, int, int, float, float, float)):
 Likewise.
 * projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs (CalcDescendants):
 Changed type of parameter `inRad` to `float`.
