### PR TITLE
Add zoom support into the circle chart

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -393,8 +393,7 @@ namespace GKUI.Charts
         private void Render(Graphics context, RenderTarget target)
         {
             PointF center = GetCenter(target);
-            context.TranslateTransform(center.X, center.Y);
-            context.ScaleTransform(fZoomX, fZoomY);
+            context.Transform = new Matrix(fZoomX, 0, 0, fZoomY, center.X, center.Y);
 #if FUN_ANIM
             if (RenderTarget.rtScreen == target) {
                 context.RotateTransform((float)(3.5f * Math.Sin(fAnimationTime) *


### PR DESCRIPTION
This commit enables zoom support in a circle chart (implemented with GDI+ transformations). To change the zoom use mouse wheel while holding Ctrl key down and/or keyboard: key `w` to zoom in, `s` to zoom out and `Ctrl+0` to reset the scale to default (100%).

Please feel free to change the keys assignment in your next code changes or force me to update it before merging this PR! :wink:

ChangeLog:

2017-02-03 Ruslan Garipov <brigadir15@gmail.com>

Enable zoom in circle chart
 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (fZoomX, fZoomY): Added new
 members.
 (GetPathsBoundaryF, GetPathsBoundaryI, GetCenter, FindSegment): Added awareness
 of the current zoom factor.
 (Render): Likewise. Scaled the main GDI+ context.
 (OnKeyDown, OnMouseWheel): Added new members.
