### PR TITLE
Setup GDI+ anti-aliasing in scaled circle chart

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs
@@ -198,8 +198,6 @@ namespace GKUI.Charts
 
         protected override void InternalDraw(Graphics gfx)
         {
-            gfx.SmoothingMode = SmoothingMode.AntiAlias;
-
             int numberOfSegments = fSegments.Count;
             for (int i = 0; i < numberOfSegments; i++) {
                 PersonSegment segment = (PersonSegment)fSegments[i];

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -405,6 +405,10 @@ namespace GKUI.Charts
                 context.ScaleTransform(zoomX, zoomY);
             }
 #endif
+            context.SmoothingMode = SmoothingMode.AntiAlias;
+            if ((1.25f < fZoomX) || (1.25f < fZoomY)) {
+                context.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            }
             InternalDraw(context);
             context.ResetTransform();
         }
@@ -664,18 +668,18 @@ namespace GKUI.Charts
                 {
                     fZoomX += fZoomX * 0.05f;
                     fZoomY += fZoomY * 0.05f;
-                    Invalidate();
                     Size boundary = GetPathsBoundaryI();
-                    AdjustViewPort(boundary, false);
+                    AdjustViewPort(boundary, true);
+                    Invalidate();
                     break;
                 }
                 case Keys.S:
                 {
                     fZoomX -= fZoomX * 0.05f;
                     fZoomY -= fZoomY * 0.05f;
-                    Invalidate();
                     Size boundary = GetPathsBoundaryI();
-                    AdjustViewPort(boundary, false);
+                    AdjustViewPort(boundary, true);
+                    Invalidate();
                     break;
                 }
                 case Keys.D0:
@@ -683,9 +687,9 @@ namespace GKUI.Charts
                     if (e.Control) {
                         fZoomX = 1.0f;
                         fZoomY = 1.0f;
-                        Invalidate();
                         Size boundary = GetPathsBoundaryI();
-                        AdjustViewPort(boundary, false);
+                        AdjustViewPort(boundary, true);
+                        Invalidate();
                     }
                     break;
                 }
@@ -732,7 +736,6 @@ namespace GKUI.Charts
 
         protected override void OnMouseWheel(MouseEventArgs e)
         {
-            base.OnMouseWheel(e);
             if (Keys.None != (Keys.Control & ModifierKeys)) {
                 if (0 > e.Delta) {
                     fZoomX -= fZoomX * 0.05f;
@@ -741,9 +744,12 @@ namespace GKUI.Charts
                     fZoomX += fZoomX * 0.05f;
                     fZoomY += fZoomY * 0.05f;
                 }
-                Invalidate();
                 Size boundary = GetPathsBoundaryI();
-                AdjustViewPort(boundary, false);
+                AdjustViewPort(boundary, true);
+                Invalidate();
+            }
+            else {
+                base.OnMouseWheel(e);
             }
         }
 

--- a/projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs
@@ -151,8 +151,6 @@ namespace GKUI.Charts
 
         protected override void InternalDraw(Graphics gfx)
         {
-            gfx.SmoothingMode = SmoothingMode.AntiAlias;
-
             int numberOfSegments = fSegments.Count;
             for (int i = 0; i < numberOfSegments; i++) {
                 PersonSegment segment = (PersonSegment)fSegments[i];


### PR DESCRIPTION
As I mentioned that in #108, font smoothing must be applied to a circle chart with large zoom factors.

ChangeLog:

2017-02-03 Ruslan Garipov <brigadir15@gmail.com>

 * projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs (InternalDraw): Avoided
 changing of GDI+ context parameters.
 * projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs (InternalDraw):
 Likewise.
 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (Render): Setup parameters of
 GDI+ context (smotthing).
 (OnKeyDown): Removed double invalidating.
 (OnMouseWheel): Likewise. The base member get called only when 'Ctrl' isn't
 holded.
