### PR TITLE
Add panning ability to circle chart

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -398,9 +398,12 @@ namespace GKUI.Charts
         private void Render(Graphics context, RenderTarget target)
         {
             PointF center = GetCenter(target);
-            context.Transform = new Matrix(fZoomX, 0, 0, fZoomY, center.X, center.Y);
-#if FUN_ANIM
             if (RenderTarget.rtScreen == target) {
+                context.Transform = new Matrix(fZoomX, 0, 0, fZoomY, center.X, center.Y);
+                if ((1.25f < fZoomX) || (1.25f < fZoomY)) {
+                    context.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+                }
+#if FUN_ANIM
                 context.RotateTransform((float)(3.5f * Math.Sin(fAnimationTime) *
                                                 Math.Exp(-1.0 * fAnimationTime / fAnimationTimeLimit)));
                 float zoomX = fZoomX + ((0 != fAnimationTime) ?
@@ -408,12 +411,11 @@ namespace GKUI.Charts
                 float zoomY = fZoomY - ((0 != fAnimationTime) ?
                                         (float)(Math.Exp(-1.0 * (fAnimationTime + 50.0f) / fAnimationTimeLimit)) : 0);
                 context.ScaleTransform(zoomX, zoomY);
-            }
 #endif
-            context.SmoothingMode = SmoothingMode.AntiAlias;
-            if ((1.25f < fZoomX) || (1.25f < fZoomY)) {
-                context.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            } else {
+                context.Transform = new Matrix(1, 0, 0, 1, center.X, center.Y);
             }
+            context.SmoothingMode = SmoothingMode.AntiAlias;
             InternalDraw(context);
             context.ResetTransform();
         }

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -27,6 +27,7 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 
+using System.Windows.Forms.VisualStyles;
 using GKCommon;
 using GKCommon.GEDCOM;
 using GKCore;
@@ -116,6 +117,8 @@ namespace GKUI.Charts
         /* Zoom factors */
         private float fZoomX = 1.0f;
         private float fZoomY = 1.0f;
+        private float fZoomLowLimit = 0.0125f;
+        private float fZoomHighLimit = 1000.0f;
         /* Mouse capturing. */
         private int fMouseCaptured;
         private int fMouseCaptureX;
@@ -671,19 +674,21 @@ namespace GKUI.Charts
         protected override void OnKeyDown(KeyEventArgs e)
         {
             switch (e.KeyCode) {
-                case Keys.W:
+                case Keys.Add:
+                case Keys.Oemplus:
                 {
-                    fZoomX += fZoomX * 0.05f;
-                    fZoomY += fZoomY * 0.05f;
+                    fZoomX = Math.Min(fZoomX + fZoomX * 0.05f, fZoomHighLimit);
+                    fZoomY = Math.Min(fZoomY + fZoomY * 0.05f, fZoomHighLimit);
                     Size boundary = GetPathsBoundaryI();
                     AdjustViewPort(boundary, true);
                     Invalidate();
                     break;
                 }
-                case Keys.S:
+                case Keys.Subtract:
+                case Keys.OemMinus:
                 {
-                    fZoomX -= fZoomX * 0.05f;
-                    fZoomY -= fZoomY * 0.05f;
+                    fZoomX = Math.Max(fZoomX - fZoomX * 0.05f, fZoomLowLimit);
+                    fZoomY = Math.Max(fZoomY - fZoomY * 0.05f, fZoomLowLimit);
                     Size boundary = GetPathsBoundaryI();
                     AdjustViewPort(boundary, true);
                     Invalidate();
@@ -711,9 +716,11 @@ namespace GKUI.Charts
         protected override void OnMouseDown(MouseEventArgs e)
         {
             base.OnMouseDown(e);
-            fMouseCaptured = 1;
-            fMouseCaptureX = e.X;
-            fMouseCaptureY = e.Y;
+            if (HorizontalScroll.Visible || VerticalScroll.Visible) {
+                fMouseCaptured = 1;
+                fMouseCaptureX = e.X;
+                fMouseCaptureY = e.Y;
+            }
         }
 
         protected override void OnMouseUp(MouseEventArgs e)
@@ -769,11 +776,11 @@ namespace GKUI.Charts
         {
             if (Keys.None != (Keys.Control & ModifierKeys)) {
                 if (0 > e.Delta) {
-                    fZoomX -= fZoomX * 0.05f;
-                    fZoomY -= fZoomY * 0.05f;
+                    fZoomX = Math.Max(fZoomX - fZoomX * 0.05f, fZoomLowLimit);
+                    fZoomY = Math.Max(fZoomY - fZoomY * 0.05f, fZoomLowLimit);
                 } else {
-                    fZoomX += fZoomX * 0.05f;
-                    fZoomY += fZoomY * 0.05f;
+                    fZoomX = Math.Min(fZoomX + fZoomX * 0.05f, fZoomHighLimit);
+                    fZoomY = Math.Min(fZoomY + fZoomY * 0.05f, fZoomHighLimit);
                 }
                 Size boundary = GetPathsBoundaryI();
                 AdjustViewPort(boundary, true);

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -27,7 +27,6 @@ using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 
-using System.Windows.Forms.VisualStyles;
 using GKCommon;
 using GKCommon.GEDCOM;
 using GKCore;


### PR DESCRIPTION
It isn't necessary to use scrollbars anymore -- you can drag a big circle chart with mouse 🐭 

ChangeLog:

2017-02-03 Ruslan Garipov <brigadir15@gmail.com>

Add cricle chart panning
 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (fMouseCaptured)
 (fMouseCaptureX, fMouseCaptureY, fZoomLowLimit, fZoomHighLimit): Added new
 members.
 (OnKeyDown): Called base overridden member by `default`. Replaced hotkeys. Set
 limits on the zoom factors.
 (OnMouseDown): Added new member.
 (OnMouseUp): Reset mouse "capturing".
 (OnMouseMove): Process mouse "capturing".
 (OnMouseWheel): Set limits on the zoom factors.
 (Render): Avoided scaled non-screen rendering.
