### PR TITLE
Scroll a circle chart with the keyboard

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs
@@ -236,11 +236,15 @@ namespace GKUI.Charts
             e.Handled = false;
             switch (e.KeyCode) {
                 case Keys.Add:
-                    GenWidth += 10;
+                    if (Keys.None != (Keys.Shift & ModifierKeys)) {
+                        GenWidth += 10;
+                    }
                     break;
 
                 case Keys.Subtract:
-                    GenWidth -= 10;
+                    if (Keys.None != (Keys.Shift & ModifierKeys)) {
+                        GenWidth -= 10;
+                    }
                     break;
 
                 case Keys.Left:

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -656,6 +656,8 @@ namespace GKUI.Charts
                 case Keys.Subtract:
                 case Keys.Left:
                 case Keys.Right:
+                case Keys.Up:
+                case Keys.Down:
                 case Keys.Back:
                     return true;
             }
@@ -712,6 +714,74 @@ namespace GKUI.Charts
                         AdjustViewPort(boundary, true);
                         Invalidate();
                     }
+                    break;
+                }
+                case Keys.Left:
+                {
+                    HorizontalScroll.Value =
+                        Math.Max(HorizontalScroll.Value - HorizontalScroll.SmallChange, 0);
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Right:
+                {
+                    HorizontalScroll.Value += HorizontalScroll.SmallChange;
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Up:
+                {
+                    VerticalScroll.Value =
+                        Math.Max(VerticalScroll.Value - VerticalScroll.SmallChange, 0);
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Down:
+                {
+                    VerticalScroll.Value += VerticalScroll.SmallChange;
+                    PerformLayout();
+                    break;
+                }
+                case Keys.PageUp:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value =
+                            Math.Max(VerticalScroll.Value - VerticalScroll.LargeChange, 0);
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value =
+                            Math.Max(HorizontalScroll.Value - HorizontalScroll.LargeChange, 0);
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.PageDown:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value += VerticalScroll.LargeChange;
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value += HorizontalScroll.LargeChange;
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Home:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value = 0;
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value = 0;
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.End:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value = VerticalScroll.Maximum;
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value = HorizontalScroll.Maximum;
+                    }
+                    PerformLayout();
                     break;
                 }
                 default:

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -682,21 +682,25 @@ namespace GKUI.Charts
                 case Keys.Add:
                 case Keys.Oemplus:
                 {
-                    fZoomX = Math.Min(fZoomX + fZoomX * 0.05f, fZoomHighLimit);
-                    fZoomY = Math.Min(fZoomY + fZoomY * 0.05f, fZoomHighLimit);
-                    Size boundary = GetPathsBoundaryI();
-                    AdjustViewPort(boundary, true);
-                    Invalidate();
+                    if (Keys.None == ModifierKeys) {
+                        fZoomX = Math.Min(fZoomX + fZoomX * 0.05f, fZoomHighLimit);
+                        fZoomY = Math.Min(fZoomY + fZoomY * 0.05f, fZoomHighLimit);
+                        Size boundary = GetPathsBoundaryI();
+                        AdjustViewPort(boundary, true);
+                        Invalidate();
+                    }
                     break;
                 }
                 case Keys.Subtract:
                 case Keys.OemMinus:
                 {
-                    fZoomX = Math.Max(fZoomX - fZoomX * 0.05f, fZoomLowLimit);
-                    fZoomY = Math.Max(fZoomY - fZoomY * 0.05f, fZoomLowLimit);
-                    Size boundary = GetPathsBoundaryI();
-                    AdjustViewPort(boundary, true);
-                    Invalidate();
+                    if (Keys.None == ModifierKeys) {
+                        fZoomX = Math.Max(fZoomX - fZoomX * 0.05f, fZoomLowLimit);
+                        fZoomY = Math.Max(fZoomY - fZoomY * 0.05f, fZoomLowLimit);
+                        Size boundary = GetPathsBoundaryI();
+                        AdjustViewPort(boundary, true);
+                        Invalidate();
+                    }
                     break;
                 }
                 case Keys.D0:

--- a/projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs
@@ -174,11 +174,15 @@ namespace GKUI.Charts
             e.Handled = false;
             switch (e.KeyCode) {
                 case Keys.Add:
-                    GenWidth += 10;
+                    if (Keys.None != (Keys.Shift & ModifierKeys)) {
+                        GenWidth += 10;
+                    }
                     break;
 
                 case Keys.Subtract:
-                    GenWidth -= 10;
+                    if (Keys.None != (Keys.Shift & ModifierKeys)) {
+                        GenWidth -= 10;
+                    }
                     break;
 
                 case Keys.Back:


### PR DESCRIPTION
Being a keyboard fan this PR adds keyboard interface to a circle chart to allow some scrolling stuff:

- `Left`, `Up`, `Right` and `Down` arrow keys act as scrollbar's arrows,
- `Home` and `End` keys scroll the content to the top and bottom, correspondingly. `Shift` + `Home` and `Shift` + `End` -- to the left and to the right,
- `PgUp` and `PgDn` keys scroll the content one scrolling page up and one page down, correspondingly. `Shift` + `PgUp` and `Shift` + `PgDn` -- one page left and one page right.

ChangeLog:

2017-02-05 Ruslan Garipov <brigadir15@gmail.com>

 * projects/GEDKeeper2/GKUI/Charts/AncestorsCircle.cs (OnKeyDown): Changing
 width of segments is allowed only with `Shift` holded.
 * projects/GEDKeeper2/GKUI/Charts/DescendantsCircle.cs (OnKeyDown): Likewise.
 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (IsInputKey): Added keys `Up`
 and `Down`.
 (OnKeyDown): Zoom factor is changed only without modifying keys. Process arrow
 keys, `Home`, `End`, `PgUp` and `PgDn`.
