### PR TITLE
Unify charts behavior (partially)

### DIFF
--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -649,22 +649,6 @@ namespace GKUI.Charts
 
         #region Protected inherited methods
 
-        protected override bool IsInputKey(Keys keyData)
-        {
-            switch (keyData) {
-                case Keys.Add:
-                case Keys.Subtract:
-                case Keys.Left:
-                case Keys.Right:
-                case Keys.Up:
-                case Keys.Down:
-                case Keys.Back:
-                    return true;
-            }
-
-            return base.IsInputKey(keyData);
-        }
-
         protected override void OnPaint(PaintEventArgs e)
         {
             Render(e.Graphics, RenderTarget.rtScreen);
@@ -716,98 +700,27 @@ namespace GKUI.Charts
                     }
                     break;
                 }
-                case Keys.Left:
-                {
-                    HorizontalScroll.Value =
-                        Math.Max(HorizontalScroll.Value - HorizontalScroll.SmallChange, 0);
-                    PerformLayout();
-                    break;
-                }
-                case Keys.Right:
-                {
-                    HorizontalScroll.Value += HorizontalScroll.SmallChange;
-                    PerformLayout();
-                    break;
-                }
-                case Keys.Up:
-                {
-                    VerticalScroll.Value =
-                        Math.Max(VerticalScroll.Value - VerticalScroll.SmallChange, 0);
-                    PerformLayout();
-                    break;
-                }
-                case Keys.Down:
-                {
-                    VerticalScroll.Value += VerticalScroll.SmallChange;
-                    PerformLayout();
-                    break;
-                }
-                case Keys.PageUp:
-                {
-                    if (Keys.None == ModifierKeys) {
-                        VerticalScroll.Value =
-                            Math.Max(VerticalScroll.Value - VerticalScroll.LargeChange, 0);
-                    } else if (Keys.Shift == ModifierKeys) {
-                        HorizontalScroll.Value =
-                            Math.Max(HorizontalScroll.Value - HorizontalScroll.LargeChange, 0);
-                    }
-                    PerformLayout();
-                    break;
-                }
-                case Keys.PageDown:
-                {
-                    if (Keys.None == ModifierKeys) {
-                        VerticalScroll.Value += VerticalScroll.LargeChange;
-                    } else if (Keys.Shift == ModifierKeys) {
-                        HorizontalScroll.Value += HorizontalScroll.LargeChange;
-                    }
-                    PerformLayout();
-                    break;
-                }
-                case Keys.Home:
-                {
-                    if (Keys.None == ModifierKeys) {
-                        VerticalScroll.Value = 0;
-                    } else if (Keys.Shift == ModifierKeys) {
-                        HorizontalScroll.Value = 0;
-                    }
-                    PerformLayout();
-                    break;
-                }
-                case Keys.End:
-                {
-                    if (Keys.None == ModifierKeys) {
-                        VerticalScroll.Value = VerticalScroll.Maximum;
-                    } else if (Keys.Shift == ModifierKeys) {
-                        HorizontalScroll.Value = HorizontalScroll.Maximum;
-                    }
-                    PerformLayout();
-                    break;
-                }
-
-                case Keys.Back:
-                    NavPrev();
-                    return;
-
                 default:
+                {
                     base.OnKeyDown(e);
                     break;
+                }
             }
         }
 
         protected override void OnMouseDown(MouseEventArgs e)
         {
-            base.OnMouseDown(e);
             if ((MouseButtons.Left == e.Button) && (HorizontalScroll.Visible || VerticalScroll.Visible)) {
                 fMouseCaptured = 1;
                 fMouseCaptureX = e.X;
                 fMouseCaptureY = e.Y;
+            } else {
+                base.OnMouseDown(e);
             }
         }
 
         protected override void OnMouseUp(MouseEventArgs e)
         {
-            base.OnMouseUp(e);
             if (MouseButtons.Left == e.Button) {
                 if (2 > fMouseCaptured) {
                     CircleSegment selected = FindSegment(e.X, e.Y);
@@ -817,16 +730,13 @@ namespace GKUI.Charts
                 }
                 fMouseCaptured = 0;
                 Cursor = Cursors.Default;
-            } else if (MouseButtons.XButton1 == e.Button) {
-                NavPrev();
-            } else if (MouseButtons.XButton2 == e.Button) {
-                NavNext();
+            } else {
+                base.OnMouseUp(e);
             }
         }
 
         protected override void OnMouseMove(MouseEventArgs e)
         {
-            base.OnMouseMove(e);
             if (MouseButtons.Left == e.Button) {
                 if (0 == fMouseCaptured) {
                     CircleSegment selected = FindSegment(e.X, e.Y);
@@ -858,6 +768,8 @@ namespace GKUI.Charts
                     fMouseCaptureY = e.Y;
                     Cursor = Cursors.SizeAll;
                 }
+            } else {
+                base.OnMouseMove(e);
             }
         }
 

--- a/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CircleChart.cs
@@ -667,7 +667,6 @@ namespace GKUI.Charts
             switch (e.KeyCode) {
                 case Keys.Add:
                 case Keys.Oemplus:
-                {
                     if (Keys.None == ModifierKeys) {
                         fZoomX = Math.Min(fZoomX + fZoomX * 0.05f, fZoomHighLimit);
                         fZoomY = Math.Min(fZoomY + fZoomY * 0.05f, fZoomHighLimit);
@@ -676,10 +675,9 @@ namespace GKUI.Charts
                         Invalidate();
                     }
                     break;
-                }
+
                 case Keys.Subtract:
                 case Keys.OemMinus:
-                {
                     if (Keys.None == ModifierKeys) {
                         fZoomX = Math.Max(fZoomX - fZoomX * 0.05f, fZoomLowLimit);
                         fZoomY = Math.Max(fZoomY - fZoomY * 0.05f, fZoomLowLimit);
@@ -688,9 +686,8 @@ namespace GKUI.Charts
                         Invalidate();
                     }
                     break;
-                }
+
                 case Keys.D0:
-                {
                     if (e.Control) {
                         fZoomX = 1.0f;
                         fZoomY = 1.0f;
@@ -699,12 +696,10 @@ namespace GKUI.Charts
                         Invalidate();
                     }
                     break;
-                }
+
                 default:
-                {
                     base.OnKeyDown(e);
                     break;
-                }
             }
         }
 

--- a/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
@@ -72,15 +72,12 @@ namespace GKUI.Charts
                 case Keys.Up:
                 case Keys.Down:
                 case Keys.Back:
-                {
                     return true;
                     break;
-                }
+
                 default:
-                {
                     return base.IsInputKey(keyData);
                     break;
-                }
             }
         }
 
@@ -89,33 +86,28 @@ namespace GKUI.Charts
             e.Handled = true;
             switch (e.KeyCode) {
                 case Keys.Left:
-                {
                     HorizontalScroll.Value =
                         Math.Max(HorizontalScroll.Value - HorizontalScroll.SmallChange, 0);
                     PerformLayout();
                     break;
-                }
+
                 case Keys.Right:
-                {
                     HorizontalScroll.Value += HorizontalScroll.SmallChange;
                     PerformLayout();
                     break;
-                }
+
                 case Keys.Up:
-                {
                     VerticalScroll.Value =
                         Math.Max(VerticalScroll.Value - VerticalScroll.SmallChange, 0);
                     PerformLayout();
                     break;
-                }
+
                 case Keys.Down:
-                {
                     VerticalScroll.Value += VerticalScroll.SmallChange;
                     PerformLayout();
                     break;
-                }
+
                 case Keys.PageUp:
-                {
                     if (Keys.None == ModifierKeys) {
                         VerticalScroll.Value =
                             Math.Max(VerticalScroll.Value - VerticalScroll.LargeChange, 0);
@@ -125,9 +117,8 @@ namespace GKUI.Charts
                     }
                     PerformLayout();
                     break;
-                }
+
                 case Keys.PageDown:
-                {
                     if (Keys.None == ModifierKeys) {
                         VerticalScroll.Value += VerticalScroll.LargeChange;
                     } else if (Keys.Shift == ModifierKeys) {
@@ -135,9 +126,8 @@ namespace GKUI.Charts
                     }
                     PerformLayout();
                     break;
-                }
+
                 case Keys.Home:
-                {
                     if (Keys.None == ModifierKeys) {
                         VerticalScroll.Value = 0;
                     } else if (Keys.Shift == ModifierKeys) {
@@ -145,9 +135,8 @@ namespace GKUI.Charts
                     }
                     PerformLayout();
                     break;
-                }
+
                 case Keys.End:
-                {
                     if (Keys.None == ModifierKeys) {
                         VerticalScroll.Value = VerticalScroll.Maximum;
                     } else if (Keys.Shift == ModifierKeys) {
@@ -155,17 +144,14 @@ namespace GKUI.Charts
                     }
                     PerformLayout();
                     break;
-                }
+
                 case Keys.Back:
-                {
                     NavPrev();
                     break;
-                }
+
                 default:
-                {
                     base.OnKeyDown(e);
                     break;
-                }
             }
         }
 

--- a/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/CustomChart.cs
@@ -22,6 +22,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using System.Windows.Forms;
 
 using GKCommon;
 using GKCommon.Controls;
@@ -61,6 +62,138 @@ namespace GKUI.Charts
                 if (fNavman != null) fNavman.Dispose();
             }
             base.Dispose(disposing);
+        }
+
+        protected override bool IsInputKey(Keys keyData)
+        {
+            switch (keyData) {
+                case Keys.Left:
+                case Keys.Right:
+                case Keys.Up:
+                case Keys.Down:
+                case Keys.Back:
+                {
+                    return true;
+                    break;
+                }
+                default:
+                {
+                    return base.IsInputKey(keyData);
+                    break;
+                }
+            }
+        }
+
+        protected override void OnKeyDown(KeyEventArgs e)
+        {
+            e.Handled = true;
+            switch (e.KeyCode) {
+                case Keys.Left:
+                {
+                    HorizontalScroll.Value =
+                        Math.Max(HorizontalScroll.Value - HorizontalScroll.SmallChange, 0);
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Right:
+                {
+                    HorizontalScroll.Value += HorizontalScroll.SmallChange;
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Up:
+                {
+                    VerticalScroll.Value =
+                        Math.Max(VerticalScroll.Value - VerticalScroll.SmallChange, 0);
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Down:
+                {
+                    VerticalScroll.Value += VerticalScroll.SmallChange;
+                    PerformLayout();
+                    break;
+                }
+                case Keys.PageUp:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value =
+                            Math.Max(VerticalScroll.Value - VerticalScroll.LargeChange, 0);
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value =
+                            Math.Max(HorizontalScroll.Value - HorizontalScroll.LargeChange, 0);
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.PageDown:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value += VerticalScroll.LargeChange;
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value += HorizontalScroll.LargeChange;
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Home:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value = 0;
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value = 0;
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.End:
+                {
+                    if (Keys.None == ModifierKeys) {
+                        VerticalScroll.Value = VerticalScroll.Maximum;
+                    } else if (Keys.Shift == ModifierKeys) {
+                        HorizontalScroll.Value = HorizontalScroll.Maximum;
+                    }
+                    PerformLayout();
+                    break;
+                }
+                case Keys.Back:
+                {
+                    NavPrev();
+                    break;
+                }
+                default:
+                {
+                    base.OnKeyDown(e);
+                    break;
+                }
+            }
+        }
+
+        protected override void OnMouseUp(MouseEventArgs e)
+        {
+            if (MouseButtons.XButton1 == e.Button) {
+                NavPrev();
+            } else if (MouseButtons.XButton2 == e.Button) {
+                NavNext();
+            } else {
+                base.OnMouseUp(e);
+            }
+        }
+
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            if (Keys.None == ModifierKeys) {
+                VerticalScroll.Value =
+                    Math.Max(VerticalScroll.Value - e.Delta, 0);
+                PerformLayout();
+            } else if (Keys.Shift == ModifierKeys) {
+                HorizontalScroll.Value =
+                    Math.Max(HorizontalScroll.Value - e.Delta, 0);
+                PerformLayout();
+            }
+            else {
+                base.OnMouseWheel(e);
+            }
         }
 
         #region Print and snaphots support

--- a/projects/GEDKeeper2/GKUI/Charts/TreeChartBox.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/TreeChartBox.cs
@@ -1789,39 +1789,28 @@ namespace GKUI.Charts
 
         #region Protected methods
 
-        protected override bool IsInputKey(Keys keyData)
-        {
-            switch (keyData) {
-                case Keys.Add:
-                case Keys.Subtract:
-                case Keys.Back:
-                    return true;
-            }
-
-            return base.IsInputKey(keyData);
-        }
-
         protected override void OnKeyDown(KeyEventArgs e)
         {
-            base.OnKeyDown(e);
-
-            e.Handled = false;
             switch (e.KeyCode) {
                 case Keys.Add:
+                case Keys.Oemplus:
+                {
                     SetScale(fScale + 0.05f);
-                    break;
-
-                case Keys.Subtract:
-                    SetScale(fScale - 0.05f);
-                    break;
-
-                case Keys.Back:
-                    NavPrev();
-                    return;
-
-                default:
                     e.Handled = true;
                     break;
+                }
+                case Keys.Subtract:
+                case Keys.OemMinus:
+                {
+                    SetScale(fScale - 0.05f);
+                    e.Handled = true;
+                    break;
+                }
+                default:
+                {
+                    base.OnKeyDown(e);
+                    break;
+                }
             }
         }
 
@@ -1857,19 +1846,11 @@ namespace GKUI.Charts
 
         protected override void OnMouseWheel(MouseEventArgs e)
         {
-            //base.OnMouseWheel(e);
             if (ModifierKeys == Keys.Control) {
-                float newScale = (e.Delta > 0) ? fScale - 0.05f : fScale + 0.05f;
-
+                float newScale = (e.Delta > 0) ? fScale + 0.05f : fScale - 0.05f;
                 SetScale(newScale);
             } else {
-                int dx = 0, dy = 0;
-                if (ModifierKeys == Keys.Shift) {
-                    dx = -e.Delta;
-                } else {
-                    dy = -e.Delta;
-                }
-                AdjustScroll(dx, dy);
+                base.OnMouseWheel(e);
             }
         }
 
@@ -1905,8 +1886,6 @@ namespace GKUI.Charts
         protected override void OnMouseDown(MouseEventArgs e)
         {
             base.OnMouseDown(e);
-            if (!Focused) Focus();
-
             fMouseX = e.X;
             fMouseY = e.Y;
 
@@ -1998,6 +1977,7 @@ namespace GKUI.Charts
 
                     switch (mAct) {
                         case MouseAction.maNone:
+                            base.OnMouseUp(e);
                             break;
 
                         case MouseAction.maProperties:

--- a/projects/GEDKeeper2/GKUI/Charts/TreeChartBox.cs
+++ b/projects/GEDKeeper2/GKUI/Charts/TreeChartBox.cs
@@ -1794,23 +1794,19 @@ namespace GKUI.Charts
             switch (e.KeyCode) {
                 case Keys.Add:
                 case Keys.Oemplus:
-                {
                     SetScale(fScale + 0.05f);
                     e.Handled = true;
                     break;
-                }
+
                 case Keys.Subtract:
                 case Keys.OemMinus:
-                {
                     SetScale(fScale - 0.05f);
                     e.Handled = true;
                     break;
-                }
+
                 default:
-                {
                     base.OnKeyDown(e);
                     break;
-                }
             }
         }
 


### PR DESCRIPTION
This PR partially unifies charts behavior -- tree and circle charts. Their common behavior is now under control of the single code.

There is one common stuff remained. That's scaling. Circle chart uses GDI+ transformations to implement zoom in/out functions. Tree chart recalculates its layout by itself. It's up to @Serg-Norseman to decide what to do with that.

ChangeLog:

2017-02-06 Ruslan Garipov <brigadir15@gmail.com>

 * projects/GEDKeeper2/GKUI/Charts/CircleChart.cs (IsInputKey): Removed member.
 (OnKeyDown): Removed processing of keys "Left", "Right", "Up", "Down", "PgUp",
 "PgDn", "Home", "End" and "Backspace". The base overridden member is called
 only when it's necessary.
 (OnMouseDown): The base overridden member is called only when it's necessary.
 (OnMouseMove): Likewise.
 (OnMouseUp): Likewise. X-buttons are not processed anymore here.
 * projects/GEDKeeper2/GKUI/Charts/CustomChart.cs (IsInputKey, OnKeyDown)
 (OnMouseUp, OnMouseWheel): Added new member.
 * projects/GEDKeeper2/GKUI/Charts/TreeChartBox.cs (IsInputKey): Removed member.
 (OnKeyDown): Removed processing of "Backspace". Add handling of the "OEM Plus"
 and "OEM Minus". The base overridden member is called only when it's necessary.
 (OnMouseWheel): Remove scrolling processing. The base overridden member is
 called only when it's necessary.
 (OnMouseUp): Call the base member when necessary.
