### PR TITLE
Fix NullReferenceException in SearchTreeFragments

### DIFF
--- a/projects/GKCore/GKCore/Tools/TreeTools.cs
+++ b/projects/GKCore/GKCore/Tools/TreeTools.cs
@@ -428,6 +428,7 @@ namespace GKCore.Tools
                 while (extTree.RecordsCount > 0) {
                     GDMRecord rec = extTree.Extract(0);
                     var oldXRef = rec.XRef;
+                    rec.SetXRef(null, null);
                     var newXRef = mainTree.NewXRef(rec);
                     repMap.AddXRef(rec, oldXRef, newXRef);
                     rec.ResetOwner(mainTree);


### PR DESCRIPTION
`mainTree.NewXRef(rec)` is trying to remove "old" XRef from the new tree 
and if there is a match it removes an incorrect record. To avoid that behavior
explicitly set XRef for record to `null` before creating a new XRef.