### PR TITLE
Complete remove GDMPointer.GetPtrValue

### DIFF
--- a/projects/GKCore/GDModel/GDMCommunicationRecord.cs
+++ b/projects/GKCore/GDModel/GDMCommunicationRecord.cs
@@ -97,7 +97,7 @@ namespace GDModel
         }
 
 
-        public GDMCommunicationRecord(GDMObject owner) : base(owner)
+        public GDMCommunicationRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType._COMM);
 

--- a/projects/GKCore/GDModel/GDMFamilyRecord.cs
+++ b/projects/GKCore/GDModel/GDMFamilyRecord.cs
@@ -66,7 +66,7 @@ namespace GDModel
         }
 
 
-        public GDMFamilyRecord(GDMObject owner) : base(owner)
+        public GDMFamilyRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.FAM);
 
@@ -108,12 +108,12 @@ namespace GDModel
         {
             base.Clear();
 
-            RemoveSpouse(fHusband.GetPtrValue<GDMIndividualRecord>());
-            RemoveSpouse(fWife.GetPtrValue<GDMIndividualRecord>());
+            RemoveSpouse(fTree.GetPtrValue<GDMIndividualRecord>(fHusband));
+            RemoveSpouse(fTree.GetPtrValue<GDMIndividualRecord>(fWife));
 
             int num = fChildren.Count;
             for (int i = 0; i < num; i++) {
-                GDMIndividualRecord child = fChildren[i].GetPtrValue<GDMIndividualRecord>();
+                GDMIndividualRecord child = fTree.GetPtrValue<GDMIndividualRecord>(fChildren[i]);
                 child.DeleteChildToFamilyLink(this);
             }
             fChildren.Clear();
@@ -188,17 +188,16 @@ namespace GDModel
 
             base.MoveTo(targetRecord);
 
-            targetFamily.RemoveSpouse(targetFamily.Husband.GetPtrValue<GDMIndividualRecord>());
+            targetFamily.RemoveSpouse(fTree.GetPtrValue<GDMIndividualRecord>(targetFamily.Husband));
             targetFamily.Husband.XRef = fHusband.XRef;
 
-            targetFamily.RemoveSpouse(targetFamily.Wife.GetPtrValue<GDMIndividualRecord>());
+            targetFamily.RemoveSpouse(fTree.GetPtrValue<GDMIndividualRecord>(targetFamily.Wife));
             targetFamily.Wife.XRef = fWife.XRef;
 
             targetFamily.Status = fStatus;
 
             while (fChildren.Count > 0) {
                 GDMIndividualLink obj = fChildren.Extract(0);
-                obj.ResetOwner(targetFamily);
                 targetFamily.Children.Add(obj);
             }
         }
@@ -216,10 +215,10 @@ namespace GDModel
         {
             string result = "";
 
-            GDMIndividualRecord spouse = fHusband.GetPtrValue<GDMIndividualRecord>();
+            GDMIndividualRecord spouse = fTree.GetPtrValue<GDMIndividualRecord>(fHusband);
             result += (spouse == null) ? "?" : spouse.GetPrimaryFullName();
             result += " - ";
-            spouse = fWife.GetPtrValue<GDMIndividualRecord>();
+            spouse = fTree.GetPtrValue<GDMIndividualRecord>(fWife);
             result += (spouse == null) ? "?" : spouse.GetPrimaryFullName();
 
             return result;

--- a/projects/GKCore/GDModel/GDMGroupRecord.cs
+++ b/projects/GKCore/GDModel/GDMGroupRecord.cs
@@ -42,7 +42,7 @@ namespace GDModel
         }
 
 
-        public GDMGroupRecord(GDMObject owner) : base(owner)
+        public GDMGroupRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType._GROUP);
 

--- a/projects/GKCore/GDModel/GDMIndividualRecord.cs
+++ b/projects/GKCore/GDModel/GDMIndividualRecord.cs
@@ -111,7 +111,7 @@ namespace GDModel
         }
 
 
-        public GDMIndividualRecord(GDMObject owner) : base(owner)
+        public GDMIndividualRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.INDI);
 
@@ -173,19 +173,19 @@ namespace GDModel
             fSex = GDMSex.svUnknown;
 
             for (int i = fChildToFamilyLinks.Count - 1; i >= 0; i--) {
-                var family = fChildToFamilyLinks[i].GetPtrValue<GDMFamilyRecord>();
+                var family = fTree.GetPtrValue<GDMFamilyRecord>(fChildToFamilyLinks[i]);
                 family.DeleteChild(this);
             }
             fChildToFamilyLinks.Clear();
 
             for (int i = fSpouseToFamilyLinks.Count - 1; i >= 0; i--) {
-                var family = fSpouseToFamilyLinks[i].GetPtrValue<GDMFamilyRecord>();
+                var family = fTree.GetPtrValue<GDMFamilyRecord>(fSpouseToFamilyLinks[i]);
                 family.RemoveSpouse(this);
             }
             fSpouseToFamilyLinks.Clear();
 
             for (int i = fGroups.Count - 1; i >= 0; i--) {
-                var group = fGroups[i].GetPtrValue<GDMGroupRecord>();
+                var group = fTree.GetPtrValue<GDMGroupRecord>(fGroups[i]);
                 group.RemoveMember(this);
             }
             fGroups.Clear();
@@ -309,7 +309,6 @@ namespace GDModel
 
             while (fPersonalNames.Count > 0) {
                 GDMPersonalName obj = fPersonalNames.Extract(0);
-                obj.ResetOwner(targetIndi);
                 targetIndi.AddPersonalName(obj);
             }
 
@@ -318,7 +317,7 @@ namespace GDModel
 
             while (fChildToFamilyLinks.Count > 0) {
                 GDMChildToFamilyLink ctfLink = fChildToFamilyLinks.Extract(0);
-                var family = ctfLink.GetPtrValue<GDMFamilyRecord>();
+                var family = fTree.GetPtrValue<GDMFamilyRecord>(ctfLink);
 
                 int num = family.Children.Count;
                 for (int i = 0; i < num; i++) {
@@ -329,13 +328,12 @@ namespace GDModel
                     }
                 }
 
-                ctfLink.ResetOwner(targetIndi);
                 targetIndi.ChildToFamilyLinks.Add(ctfLink);
             }
 
             while (fSpouseToFamilyLinks.Count > 0) {
                 GDMSpouseToFamilyLink stfLink = fSpouseToFamilyLinks.Extract(0);
-                var family = stfLink.GetPtrValue<GDMFamilyRecord>();
+                var family = fTree.GetPtrValue<GDMFamilyRecord>(stfLink);
 
                 if (family.Husband.XRef == currentXRef) {
                     family.Husband.XRef = targetXRef;
@@ -343,19 +341,16 @@ namespace GDModel
                     family.Wife.XRef = targetXRef;
                 }
 
-                stfLink.ResetOwner(targetIndi);
                 targetIndi.SpouseToFamilyLinks.Add(stfLink);
             }
 
             while (fAssociations.Count > 0) {
                 GDMAssociation obj = fAssociations.Extract(0);
-                obj.ResetOwner(targetIndi);
                 targetIndi.Associations.Add(obj);
             }
 
             while (fGroups.Count > 0) {
                 GDMPointer obj = fGroups.Extract(0);
-                obj.ResetOwner(targetIndi);
                 targetIndi.Groups.Add(obj);
             }
         }

--- a/projects/GKCore/GDModel/GDMLocationRecord.cs
+++ b/projects/GKCore/GDModel/GDMLocationRecord.cs
@@ -42,7 +42,7 @@ namespace GDModel
         }
 
 
-        public GDMLocationRecord(GDMObject owner) : base(owner)
+        public GDMLocationRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType._LOC);
 

--- a/projects/GKCore/GDModel/GDMMultimediaRecord.cs
+++ b/projects/GKCore/GDModel/GDMMultimediaRecord.cs
@@ -33,7 +33,7 @@ namespace GDModel
         }
 
 
-        public GDMMultimediaRecord(GDMObject owner) : base(owner)
+        public GDMMultimediaRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.OBJE);
 

--- a/projects/GKCore/GDModel/GDMNoteRecord.cs
+++ b/projects/GKCore/GDModel/GDMNoteRecord.cs
@@ -34,7 +34,7 @@ namespace GDModel
         }
 
 
-        public GDMNoteRecord(GDMObject owner) : base(owner)
+        public GDMNoteRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.NOTE);
 

--- a/projects/GKCore/GDModel/GDMPointer.cs
+++ b/projects/GKCore/GDModel/GDMPointer.cs
@@ -32,12 +32,6 @@ namespace GDModel
             get { return (!string.IsNullOrEmpty(fXRef)); }
         }
 
-        public T GetPtrValue<T>() where T : GDMRecord
-        {
-            GDMTree tree = GetTree();
-            return (tree == null) ? null : tree.XRefIndex_Find(XRef) as T;
-        }
-
         // TODO: how to be sure that the record will have the correct XRef in the required places?
         public string XRef
         {
@@ -83,29 +77,6 @@ namespace GDModel
             if (map != null) {
                 XRef = map.FindNewXRef(XRef);
             }
-        }
-
-        private GDMTree GetTree()
-        {
-            GDMTree owner = null;
-
-            GDMTag current = this;
-            while (current != null) {
-                GDMObject parent = current.Owner;
-
-                var parentTag = parent as GDMTag;
-                if (parentTag != null) {
-                    current = parentTag;
-                } else {
-                    var parentTree = parent as GDMTree;
-                    if (parentTree != null) {
-                        owner = parentTree;
-                    }
-                    break;
-                }
-            }
-
-            return owner;
         }
     }
 }

--- a/projects/GKCore/GDModel/GDMRecord.cs
+++ b/projects/GKCore/GDModel/GDMRecord.cs
@@ -50,6 +50,7 @@ namespace GDModel
     /// </summary>
     public class GDMRecord : GDMTag, IGDMStructWithLists, IGDMStructWithUserReferences
     {
+        protected GDMTree fTree;
         private string fAutomatedRecordID;
         private GDMChangeDate fChangeDate;
         private string fUID;
@@ -113,8 +114,9 @@ namespace GDModel
             get { return fXRef; }
         }
 
-        public GDMRecord(GDMObject owner) : base(owner)
+        public GDMRecord(GDMTree tree) : base(tree)
         {
+            fTree = tree;
             fXRef = string.Empty;
             fAutomatedRecordID = string.Empty;
             fChangeDate = new GDMChangeDate(this);
@@ -133,6 +135,11 @@ namespace GDModel
                 fUserReferences.Dispose();
             }
             base.Dispose(disposing);
+        }
+
+        public void ResetTree(GDMTree tree)
+        {
+            fTree = tree;
         }
 
         internal override void TrimExcess()
@@ -182,32 +189,27 @@ namespace GDModel
                 if (tag.GetTagType() == GEDCOMTagType.CHAN) {
                     tag.Dispose();
                 } else {
-                    tag.ResetOwner(targetRecord);
                     targetRecord.AddTag(tag);
                 }
             }
 
             while (fNotes.Count > 0) {
                 GDMTag tag = fNotes.Extract(0);
-                tag.ResetOwner(targetRecord);
                 targetRecord.Notes.Add((GDMNotes)tag);
             }
 
             while (fMultimediaLinks.Count > 0) {
                 GDMTag tag = fMultimediaLinks.Extract(0);
-                tag.ResetOwner(targetRecord);
                 targetRecord.MultimediaLinks.Add((GDMMultimediaLink)tag);
             }
 
             while (fSourceCitations.Count > 0) {
                 GDMTag tag = fSourceCitations.Extract(0);
-                tag.ResetOwner(targetRecord);
                 targetRecord.SourceCitations.Add((GDMSourceCitation)tag);
             }
 
             while (fUserReferences.Count > 0) {
                 GDMTag tag = fUserReferences.Extract(0);
-                tag.ResetOwner(targetRecord);
                 targetRecord.UserReferences.Add((GDMUserReference)tag);
             }
         }

--- a/projects/GKCore/GDModel/GDMRecordWithEvents.cs
+++ b/projects/GKCore/GDModel/GDMRecordWithEvents.cs
@@ -53,7 +53,7 @@ namespace GDModel
         }
 
 
-        protected GDMRecordWithEvents(GDMObject owner) : base(owner)
+        protected GDMRecordWithEvents(GDMTree tree) : base(tree)
         {
             fEvents = new GDMList<GDMCustomEvent>(this);
         }
@@ -115,7 +115,6 @@ namespace GDModel
 
             while (fEvents.Count > 0) {
                 GDMCustomEvent obj = fEvents.Extract(0);
-                obj.ResetOwner(target);
                 target.AddEvent(obj);
             }
 

--- a/projects/GKCore/GDModel/GDMRepositoryRecord.cs
+++ b/projects/GKCore/GDModel/GDMRepositoryRecord.cs
@@ -42,7 +42,7 @@ namespace GDModel
         }
 
 
-        public GDMRepositoryRecord(GDMObject owner) : base(owner)
+        public GDMRepositoryRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.REPO);
 

--- a/projects/GKCore/GDModel/GDMResearchRecord.cs
+++ b/projects/GKCore/GDModel/GDMResearchRecord.cs
@@ -113,7 +113,7 @@ namespace GDModel
         }
 
 
-        public GDMResearchRecord(GDMObject owner) : base(owner)
+        public GDMResearchRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType._RESEARCH);
 

--- a/projects/GKCore/GDModel/GDMSourceRecord.cs
+++ b/projects/GKCore/GDModel/GDMSourceRecord.cs
@@ -72,7 +72,7 @@ namespace GDModel
         }
 
 
-        public GDMSourceRecord(GDMObject owner) : base(owner)
+        public GDMSourceRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.SOUR);
 
@@ -172,7 +172,6 @@ namespace GDModel
 
             while (fRepositoryCitations.Count > 0) {
                 GDMRepositoryCitation obj = fRepositoryCitations.Extract(0);
-                obj.ResetOwner(targetSource);
                 targetSource.RepositoryCitations.Add(obj);
             }
         }

--- a/projects/GKCore/GDModel/GDMSubmissionRecord.cs
+++ b/projects/GKCore/GDModel/GDMSubmissionRecord.cs
@@ -75,7 +75,7 @@ namespace GDModel
         }
 
 
-        public GDMSubmissionRecord(GDMObject owner) : base(owner)
+        public GDMSubmissionRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.SUBN);
 

--- a/projects/GKCore/GDModel/GDMSubmitterRecord.cs
+++ b/projects/GKCore/GDModel/GDMSubmitterRecord.cs
@@ -52,7 +52,7 @@ namespace GDModel
         }
 
 
-        public GDMSubmitterRecord(GDMObject owner) : base(owner)
+        public GDMSubmitterRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType.SUBM);
 

--- a/projects/GKCore/GDModel/GDMTag.cs
+++ b/projects/GKCore/GDModel/GDMTag.cs
@@ -37,7 +37,6 @@ namespace GDModel
         #region Protected fields
 
         private int fId;
-        private GDMObject fOwner;
         private GDMList<GDMTag> fTags;
 
         #endregion
@@ -47,11 +46,6 @@ namespace GDModel
         public int Id
         {
             get { return fId; }
-        }
-
-        public GDMObject Owner
-        {
-            get { return fOwner; }
         }
 
         public string StringValue
@@ -80,8 +74,6 @@ namespace GDModel
         public GDMTag(GDMObject owner)
         {
             fId = 0; // Unknown
-            fOwner = owner;
-            //fTags = new GDMList<GDMTag>(this);
         }
 
         public GDMTag(GDMObject owner, int tagId, string tagValue) : this(owner)
@@ -98,11 +90,6 @@ namespace GDModel
                 }
             }
             base.Dispose(disposing);
-        }
-
-        public void ResetOwner(GDMObject owner)
-        {
-            fOwner = owner;
         }
 
         public virtual void ReplaceXRefs(GDMXRefReplacer map)

--- a/projects/GKCore/GDModel/GDMTaskRecord.cs
+++ b/projects/GKCore/GDModel/GDMTaskRecord.cs
@@ -66,7 +66,7 @@ namespace GDModel
         }
 
 
-        public GDMTaskRecord(GDMObject owner) : base(owner)
+        public GDMTaskRecord(GDMTree tree) : base(tree)
         {
             SetName(GEDCOMTagType._TASK);
 

--- a/projects/GKCore/GKCore/Controllers/EventEditDlgController.cs
+++ b/projects/GKCore/GKCore/Controllers/EventEditDlgController.cs
@@ -158,7 +158,7 @@ namespace GKCore.Controllers
 
                 if (fEvent is GDMIndividualEvent) {
                     if (GKData.PersonEvents[eventType].Kind == PersonEventKind.ekFact) {
-                        var attr = new GDMIndividualAttribute(fEvent.Owner);
+                        var attr = new GDMIndividualAttribute(null);
                         attr.Assign(fEvent);
                         fEvent = attr;
                     }

--- a/projects/GKCore/GKCore/Tools/TreeTools.cs
+++ b/projects/GKCore/GKCore/Tools/TreeTools.cs
@@ -434,7 +434,7 @@ namespace GKCore.Tools
                     var oldXRef = rec.XRef;
                     var newXRef = mainTree.NewXRef(rec);
                     repMap.AddXRef(rec, oldXRef, newXRef);
-                    rec.ResetOwner(mainTree);
+                    rec.ResetTree(mainTree);
                     mainTree.AddRecord(rec);
                 }
 

--- a/projects/GKTests/GDModel/GDMFamilyRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMFamilyRecordTests.cs
@@ -193,7 +193,7 @@ namespace GDModel
                     Assert.AreEqual(evt, famRec2.FindEvent(GEDCOMTagType.MARR));
                 }
 
-                famRec.ResetOwner(tree);
+                famRec.ResetTree(tree);
             }
         }
     }

--- a/projects/GKTests/GDModel/GDMGroupRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMGroupRecordTests.cs
@@ -46,7 +46,7 @@ namespace GDModel
             using (GDMGroupRecord grpRec = new GDMGroupRecord(fContext.Tree)) {
                 Assert.IsNotNull(grpRec);
 
-                grpRec.ResetOwner(fContext.Tree);
+                grpRec.ResetTree(fContext.Tree);
             }
 
             using (GDMGroupRecord groupRec = fContext.Tree.CreateGroup()) {

--- a/projects/GKTests/GDModel/GDMIndividualRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMIndividualRecordTests.cs
@@ -203,7 +203,7 @@ namespace GDModel
                     Assert.AreEqual("Petrov Ivan [BigHead]", st);
                 }
 
-                indi.ResetOwner(fContext.Tree);
+                indi.ResetTree(fContext.Tree);
             }
 
             indiRec.ReplaceXRefs(new GDMXRefReplacer());

--- a/projects/GKTests/GDModel/GDMMultimediaRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMMultimediaRecordTests.cs
@@ -47,7 +47,7 @@ namespace GDModel
             using (GDMMultimediaRecord mediaRec = fContext.Tree.CreateMultimedia()) {
                 Assert.IsNotNull(mediaRec);
 
-                mediaRec.ResetOwner(fContext.Tree);
+                mediaRec.ResetTree(fContext.Tree);
 
                 Assert.AreEqual("", mediaRec.GetFileTitle());
 

--- a/projects/GKTests/GDModel/GDMPersonalNameTests.cs
+++ b/projects/GKTests/GDModel/GDMPersonalNameTests.cs
@@ -228,8 +228,6 @@ namespace GDModel
                 }
             }
 
-            persName.ResetOwner(fContext.Tree);
-
             persName.Clear();
             Assert.IsTrue(persName.IsEmpty());
         }

--- a/projects/GKTests/GDModel/GDMResearchRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMResearchRecordTests.cs
@@ -53,7 +53,7 @@ namespace GDModel
             Assert.IsNotNull(groupRec);
 
             using (GDMResearchRecord resRec = fContext.Tree.CreateResearch()) {
-                resRec.ResetOwner(fContext.Tree);
+                resRec.ResetTree(fContext.Tree);
 
                 Assert.IsNotNull(resRec.Communications);
                 Assert.IsNotNull(resRec.Groups);

--- a/projects/GKTests/GDModel/GDMSourceRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMSourceRecordTests.cs
@@ -63,7 +63,7 @@ namespace GDModel
                     Assert.AreEqual(100.0f, src1.IsMatch(src2, new MatchParams()));
                 }
 
-                src1.ResetOwner(fContext.Tree);
+                src1.ResetTree(fContext.Tree);
             }
 
             // check move

--- a/projects/GKTests/GDModel/GDMSubmitterRecordTests.cs
+++ b/projects/GKTests/GDModel/GDMSubmitterRecordTests.cs
@@ -70,7 +70,7 @@ namespace GDModel
                 Assert.IsTrue(subrRec.IsEmpty());
 
 
-                subrRec.ResetOwner(fContext.Tree);
+                subrRec.ResetTree(fContext.Tree);
             }
         }
 


### PR DESCRIPTION
In this PR I successfully removed the `GDMPointer.GetPtrValue` method and `GDMPointer.Owner` property.

I've decided to go this way for a simple reason: this is an approach with far less code changes than other I tried. Other require a sophisticated refactoring around `MoveTo` and complete elimination of `Clear` methods. Also, it was not clear how to deal with `GDMFamilyRecord.IsMatch` as it does not have an apparent way to obtain the `GDMTree` object.

Another simple approach would be to provide `GDMTree tree` parameter to the `MoveTo`, `Clear` and `IsMatch` records, but I don't quite like it.

Also, I decided not to remove `GDMObject owner` parameter from `GDMTag` constructor as it would just make the review harder and bury the actual change in a lot of noise. 