### PR TITLE
Set Patronymic enabled/disabled flag accroding to the language of the name

### DIFF
--- a/projects/GKCore/GKCore/Controllers/PersonalNameEditDlgController.cs
+++ b/projects/GKCore/GKCore/Controllers/PersonalNameEditDlgController.cs
@@ -21,6 +21,7 @@
 using System;
 using GDModel;
 using GDModel.Providers.GEDCOM;
+using GKCore.Cultures;
 using GKCore.Interfaces;
 using GKCore.MVP;
 using GKCore.MVP.Views;
@@ -120,12 +121,33 @@ namespace GKCore.Controllers
                 fView.MarriedSurname.Enabled = true;
             }
 
-            ICulture culture = fBase.Context.Culture;
+            ICulture culture = parts.Culture;
             fView.Surname.Enabled = fView.Surname.Enabled && culture.HasSurname();
             fView.Patronymic.Enabled = fView.Patronymic.Enabled && culture.HasPatronymic();
 
             GDMLanguageID langID = fPersonalName.Language;
             fView.Language.Text = GEDCOMUtils.GetLanguageStr(langID);
+        }
+
+        public void UpdateLanguage()
+        {
+            var selectedLanguageId = GetSelectedLanguageID();
+            var culture = CulturesPool.DefineCulture(selectedLanguageId);
+            fView.Surname.Enabled = culture.HasSurname();
+            fView.Patronymic.Enabled = culture.HasPatronymic();
+        }
+
+        private GDMLanguageID GetSelectedLanguageID()
+        {
+            var result = fView.Language.GetSelectedTag<GDMLanguageID>();
+            if (result == GDMLanguageID.Unknown) {
+                var tree = fBase.Context.Tree;
+                if (tree != null) {
+                    result = tree.Header.Language;
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/projects/GKCore/GKCore/Cultures/DefaultCulture.cs
+++ b/projects/GKCore/GKCore/Cultures/DefaultCulture.cs
@@ -130,7 +130,7 @@ namespace GKCore.Cultures
             name = !string.IsNullOrEmpty(name) ? name : stdName;
             patronymic = !string.IsNullOrEmpty(patronymic) ? patronymic : stdPatronymic;
 
-            return new NamePartsRet(surname, marriedSurname, name, patronymic);
+            return new NamePartsRet(surname, marriedSurname, name, patronymic, this);
         }
 
         public NamePartsRet GetNamePartsEx(GDMIndividualRecord iRec, bool formatted = true)
@@ -141,7 +141,7 @@ namespace GKCore.Cultures
             if (iRec.PersonalNames.Count > 0) {
                 GDMPersonalName personalName = iRec.PersonalNames[0];
 
-                NamePartsRet nameParts = this.GetNameParts(personalName);
+                NamePartsRet nameParts = GetNameParts(personalName);
 
                 if (formatted) {
                     nameParts.Surname = GKUtils.GetFmtSurname(iRec.Sex, personalName, nameParts.Surname);

--- a/projects/GKCore/GKCore/Types/NamePartsRet.cs
+++ b/projects/GKCore/GKCore/Types/NamePartsRet.cs
@@ -19,6 +19,8 @@
  */
 
 using System;
+using GKCore.Cultures;
+using GKCore.Interfaces;
 
 namespace GKCore.Types
 {
@@ -29,6 +31,7 @@ namespace GKCore.Types
 
         public string Name;
         public string Patronymic;
+        public ICulture Culture;
 
         public string MarriedSurname;
 
@@ -59,12 +62,13 @@ namespace GKCore.Types
             MarriedSurname = string.Empty;
         }
 
-        public NamePartsRet(string maidenSurname, string marriedSurname, string name, string patronymic)
+        public NamePartsRet(string maidenSurname, string marriedSurname, string name, string patronymic, ICulture culture)
         {
             Surname = maidenSurname;
             MarriedSurname = marriedSurname;
             Name = name;
             Patronymic = patronymic;
+            Culture = culture;
         }
     }
 }

--- a/projects/GKv2/GEDKeeper2/GKUI/Forms/PersonEditDlg.cs
+++ b/projects/GKv2/GEDKeeper2/GKUI/Forms/PersonEditDlg.cs
@@ -390,7 +390,7 @@ namespace GKUI.Forms
 
         private void ModifyNamesSheet(object sender, ModifyEventArgs eArgs)
         {
-            if (eArgs.Action == RecordAction.raMoveUp || eArgs.Action == RecordAction.raMoveDown) {
+            if (eArgs.Action == RecordAction.raMoveUp || eArgs.Action == RecordAction.raMoveDown || eArgs.Action == RecordAction.raEdit) {
                 fController.UpdateNameControls(fController.Person.PersonalNames[0]);
             }
         }

--- a/projects/GKv2/GEDKeeper2/GKUI/Forms/PersonalNameEditDlg.Designer.cs
+++ b/projects/GKv2/GEDKeeper2/GKUI/Forms/PersonalNameEditDlg.Designer.cs
@@ -266,6 +266,7 @@
             this.cmbLanguage.Size = new System.Drawing.Size(226, 25);
             this.cmbLanguage.Sorted = true;
             this.cmbLanguage.TabIndex = 21;
+            this.cmbLanguage.SelectedIndexChanged += new System.EventHandler(this.cmbLanguage_SelectedIndexChanged);
             // 
             // lblLanguage
             // 

--- a/projects/GKv2/GEDKeeper2/GKUI/Forms/PersonalNameEditDlg.cs
+++ b/projects/GKv2/GEDKeeper2/GKUI/Forms/PersonalNameEditDlg.cs
@@ -162,5 +162,10 @@ namespace GKUI.Forms
             base.OnFormClosing(e);
             e.Cancel = fController.CheckChangesPersistence();
         }
+
+        private void cmbLanguage_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            fController.UpdateLanguage();
+        }
     }
 }


### PR DESCRIPTION
With trees where different languages and cultures used the "Patronymic" combobox could be stuck in one state according to the main culture of the tree.