### PR TITLE
Trim display name in the interface

### DIFF
--- a/projects/GKCore/GKCore/GKUtils.cs
+++ b/projects/GKCore/GKCore/GKUtils.cs
@@ -2850,7 +2850,7 @@ namespace GKCore
                 if (!string.IsNullOrEmpty(nick)) result = result + " [" + nick + "]";
             }
 
-            return result;
+            return result.Trim();
         }
 
         public static string GetNameString(GDMIndividualRecord iRec, bool firstSurname, bool includePieces)


### PR DESCRIPTION
I have a quite a few people with an unknown surname which is set to be empty. In the interface it was displayed as an extra space in front of the name (see screenshot). Here is a quick fix to trim such names.

![image](https://user-images.githubusercontent.com/144791/113636846-d33ec600-9662-11eb-9000-2411126fc14b.png)
