### PR TITLE
Fix NullReferenceException in LanguageEditDlg

### DIFF
--- a/projects/GKCore/GKCore/Controllers/LanguageEditDlgController.cs
+++ b/projects/GKCore/GKCore/Controllers/LanguageEditDlgController.cs
@@ -62,6 +62,11 @@ namespace GKCore.Controllers
             }
         }
 
+        public override bool Cancel()
+        {
+            return true;
+        }
+
         public override void UpdateView()
         {
             fView.LanguageCombo.Text = GEDCOMUtils.GetLanguageStr(fLanguageID);


### PR DESCRIPTION
When clicking `Cancel` in `LanguageEditDlg` nothing happens. 

Because `LanguageEditDlgController` does not call `base.Init(IBaseWindow)` the `fLocalUndoman` is not initialized and remain null. This throws `NullReferenceException` in `RollbackChanges`:

https://github.com/Serg-Norseman/GEDKeeper/blob/433148cfa32a1ce7b3d683b380d7e8fc39bda573/projects/GKCore/GKCore/MVP/DialogController.cs#L70-L73

Then this exception is caught and `DialogController.Cancel` returns `false` which then translates to `DialogResult.None`.