### PR TITLE
Optimize memory

### DIFF
--- a/projects/GKCore/GDModel/GDMAssociation.cs
+++ b/projects/GKCore/GDModel/GDMAssociation.cs
@@ -35,22 +35,32 @@ namespace GDModel
             set { fRelation = value; }
         }
 
+        public int SourceCitationsCount
+        {
+            get { return fSourceCitations == null ? 0 : fSourceCitations.Count; }
+        }
+
         public GDMList<GDMSourceCitation> SourceCitations
         {
-            get { return fSourceCitations; }
+            get {
+                if (fSourceCitations == null) {
+                    fSourceCitations = new GDMList<GDMSourceCitation>();
+                }
+
+                return fSourceCitations;
+            }
         }
 
 
         public GDMAssociation()
         {
             SetName(GEDCOMTagType.ASSO);
-            fSourceCitations = new GDMList<GDMSourceCitation>();
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                fSourceCitations.Dispose();
+                if (fSourceCitations != null) fSourceCitations.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -59,25 +69,26 @@ namespace GDModel
         {
             base.TrimExcess();
 
-            fSourceCitations.TrimExcess();
+            if (fSourceCitations != null) fSourceCitations.TrimExcess();
         }
 
         public override void Clear()
         {
             base.Clear();
-            fSourceCitations.Clear();
+            if (fSourceCitations != null) fSourceCitations.Clear();
             fRelation = string.Empty;
         }
 
         public override bool IsEmpty()
         {
-            return base.IsEmpty() && string.IsNullOrEmpty(fRelation) && (fSourceCitations.Count == 0);
+            return base.IsEmpty() && string.IsNullOrEmpty(fRelation)
+                && (fSourceCitations == null || fSourceCitations.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
         {
             base.ReplaceXRefs(map);
-            fSourceCitations.ReplaceXRefs(map);
+            if (fSourceCitations != null) fSourceCitations.ReplaceXRefs(map);
         }
 
         public override void Assign(GDMTag source)
@@ -89,7 +100,7 @@ namespace GDModel
             base.Assign(sourceObj);
 
             fRelation = sourceObj.fRelation;
-            AssignList(sourceObj.fSourceCitations, fSourceCitations);
+            if (sourceObj.fSourceCitations != null) AssignList(sourceObj.fSourceCitations, SourceCitations);
         }
     }
 }

--- a/projects/GKCore/GDModel/GDMCustomEvent.cs
+++ b/projects/GKCore/GDModel/GDMCustomEvent.cs
@@ -85,9 +85,20 @@ namespace GDModel
             set { fRestriction = value; }
         }
 
+        public int NotesCount
+        {
+            get { return fNotes == null ? 0 : fNotes.Count; }
+        }
+
         public GDMList<GDMNotes> Notes
         {
-            get { return fNotes; }
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
         public GDMList<GDMSourceCitation> SourceCitations
@@ -106,7 +117,6 @@ namespace GDModel
             fAddress = new GDMAddress();
             fDate = new GDMDateValue();
             fPlace = new GDMPlace();
-            fNotes = new GDMList<GDMNotes>();
             fSourceCitations = new GDMList<GDMSourceCitation>();
             fMultimediaLinks = new GDMList<GDMMultimediaLink>();
         }
@@ -114,7 +124,7 @@ namespace GDModel
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
                 fSourceCitations.Dispose();
                 fMultimediaLinks.Dispose();
             }
@@ -128,7 +138,7 @@ namespace GDModel
             fAddress.TrimExcess();
             fDate.TrimExcess();
             fPlace.TrimExcess();
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
             fSourceCitations.TrimExcess();
             fMultimediaLinks.TrimExcess();
         }
@@ -149,7 +159,7 @@ namespace GDModel
             fPlace.Assign(sourceObj.fPlace);
             fReligiousAffilation = sourceObj.fReligiousAffilation;
             fRestriction = sourceObj.fRestriction;
-            AssignList(sourceObj.Notes, fNotes);
+            if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
             AssignList(sourceObj.SourceCitations, fSourceCitations);
             AssignList(sourceObj.MultimediaLinks, fMultimediaLinks);
         }
@@ -166,7 +176,7 @@ namespace GDModel
             fPlace.Clear();
             fReligiousAffilation = string.Empty;
             fRestriction = GDMRestriction.rnNone;
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
             fSourceCitations.Clear();
             fMultimediaLinks.Clear();
         }
@@ -176,7 +186,7 @@ namespace GDModel
             return base.IsEmpty() && fAddress.IsEmpty() && string.IsNullOrEmpty(fAgency) && string.IsNullOrEmpty(fCause)
                 && string.IsNullOrEmpty(fClassification) && fDate.IsEmpty() && fPlace.IsEmpty()
                 && string.IsNullOrEmpty(fReligiousAffilation) && (fRestriction == GDMRestriction.rnNone)
-                && (fNotes.Count == 0) && (fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
+                && (fNotes == null || fNotes.Count == 0) && (fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
@@ -186,7 +196,7 @@ namespace GDModel
             fAddress.ReplaceXRefs(map);
             fDate.ReplaceXRefs(map);
             fPlace.ReplaceXRefs(map);
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
             fSourceCitations.ReplaceXRefs(map);
             fMultimediaLinks.ReplaceXRefs(map);
         }

--- a/projects/GKCore/GDModel/GDMCustomEvent.cs
+++ b/projects/GKCore/GDModel/GDMCustomEvent.cs
@@ -129,9 +129,20 @@ namespace GDModel
             }
         }
 
+        public int MultimediaLinksCount
+        {
+            get { return fMultimediaLinks == null ? 0 : fMultimediaLinks.Count; }
+        }
+
         public GDMList<GDMMultimediaLink> MultimediaLinks
         {
-            get { return fMultimediaLinks; }
+            get {
+                if (fMultimediaLinks == null) {
+                    fMultimediaLinks = new GDMList<GDMMultimediaLink>();
+                }
+
+                return fMultimediaLinks;
+            }
         }
 
         public bool HasPlace
@@ -143,7 +154,6 @@ namespace GDModel
         protected GDMCustomEvent()
         {
             fDate = new GDMDateValue();
-            fMultimediaLinks = new GDMList<GDMMultimediaLink>();
         }
 
         protected override void Dispose(bool disposing)
@@ -151,7 +161,7 @@ namespace GDModel
             if (disposing) {
                 if (fNotes != null) fNotes.Dispose();
                 if (fSourceCitations != null) fSourceCitations.Dispose();
-                fMultimediaLinks.Dispose();
+                if (fMultimediaLinks != null) fMultimediaLinks.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -165,7 +175,7 @@ namespace GDModel
             if (fPlace != null) fPlace.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
             if (fSourceCitations != null) fSourceCitations.TrimExcess();
-            fMultimediaLinks.TrimExcess();
+            if (fMultimediaLinks != null) fMultimediaLinks.TrimExcess();
         }
 
         public override void Assign(GDMTag source)
@@ -186,7 +196,7 @@ namespace GDModel
             fRestriction = sourceObj.fRestriction;
             if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
             if (sourceObj.fSourceCitations != null) AssignList(sourceObj.fSourceCitations, SourceCitations);
-            AssignList(sourceObj.MultimediaLinks, fMultimediaLinks);
+            if (sourceObj.fMultimediaLinks != null) AssignList(sourceObj.fMultimediaLinks, MultimediaLinks);
         }
 
         public override void Clear()
@@ -203,7 +213,7 @@ namespace GDModel
             fRestriction = GDMRestriction.rnNone;
             if (fNotes != null) fNotes.Clear();
             if (fSourceCitations != null) fSourceCitations.Clear();
-            fMultimediaLinks.Clear();
+            if (fMultimediaLinks != null) fMultimediaLinks.Clear();
         }
 
         public override bool IsEmpty()
@@ -212,7 +222,8 @@ namespace GDModel
                 && string.IsNullOrEmpty(fClassification) && fDate.IsEmpty() && (fPlace == null || fPlace.IsEmpty())
                 && string.IsNullOrEmpty(fReligiousAffilation) && (fRestriction == GDMRestriction.rnNone)
                 && (fNotes == null || fNotes.Count == 0)
-                && (fSourceCitations == null || fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
+                && (fSourceCitations == null || fSourceCitations.Count == 0)
+                && (fMultimediaLinks == null || fMultimediaLinks.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
@@ -224,7 +235,7 @@ namespace GDModel
             if (fPlace != null) fPlace.ReplaceXRefs(map);
             if (fNotes != null) fNotes.ReplaceXRefs(map);
             if (fSourceCitations != null) fSourceCitations.ReplaceXRefs(map);
-            fMultimediaLinks.ReplaceXRefs(map);
+            if (fMultimediaLinks != null) fMultimediaLinks.ReplaceXRefs(map);
         }
 
         public override float IsMatch(GDMTag tag, MatchParams matchParams)

--- a/projects/GKCore/GDModel/GDMCustomEvent.cs
+++ b/projects/GKCore/GDModel/GDMCustomEvent.cs
@@ -42,7 +42,13 @@ namespace GDModel
 
         public GDMAddress Address
         {
-            get { return fAddress; }
+            get {
+                if (fAddress == null) {
+                    fAddress = new GDMAddress();
+                }
+
+                return fAddress;
+            }
         }
 
         public string Agency
@@ -114,7 +120,6 @@ namespace GDModel
 
         protected GDMCustomEvent()
         {
-            fAddress = new GDMAddress();
             fDate = new GDMDateValue();
             fPlace = new GDMPlace();
             fSourceCitations = new GDMList<GDMSourceCitation>();
@@ -135,7 +140,7 @@ namespace GDModel
         {
             base.TrimExcess();
 
-            fAddress.TrimExcess();
+            if (fAddress != null) fAddress.TrimExcess();
             fDate.TrimExcess();
             fPlace.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
@@ -151,7 +156,7 @@ namespace GDModel
 
             base.Assign(sourceObj);
 
-            fAddress.Assign(sourceObj.fAddress);
+            if (sourceObj.fAddress != null) Address.Assign(sourceObj.fAddress);
             fAgency = sourceObj.fAgency;
             fCause = sourceObj.fCause;
             fClassification = sourceObj.fClassification;
@@ -168,7 +173,7 @@ namespace GDModel
         {
             base.Clear();
 
-            fAddress.Clear();
+            if (fAddress != null) fAddress.Clear();
             fAgency = string.Empty;
             fCause = string.Empty;
             fClassification = string.Empty;
@@ -183,7 +188,7 @@ namespace GDModel
 
         public override bool IsEmpty()
         {
-            return base.IsEmpty() && fAddress.IsEmpty() && string.IsNullOrEmpty(fAgency) && string.IsNullOrEmpty(fCause)
+            return base.IsEmpty() && (fAddress == null || fAddress.IsEmpty()) && string.IsNullOrEmpty(fAgency) && string.IsNullOrEmpty(fCause)
                 && string.IsNullOrEmpty(fClassification) && fDate.IsEmpty() && fPlace.IsEmpty()
                 && string.IsNullOrEmpty(fReligiousAffilation) && (fRestriction == GDMRestriction.rnNone)
                 && (fNotes == null || fNotes.Count == 0) && (fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
@@ -193,7 +198,7 @@ namespace GDModel
         {
             base.ReplaceXRefs(map);
 
-            fAddress.ReplaceXRefs(map);
+            if (fAddress != null) fAddress.ReplaceXRefs(map);
             fDate.ReplaceXRefs(map);
             fPlace.ReplaceXRefs(map);
             if (fNotes != null) fNotes.ReplaceXRefs(map);

--- a/projects/GKCore/GDModel/GDMCustomEvent.cs
+++ b/projects/GKCore/GDModel/GDMCustomEvent.cs
@@ -113,9 +113,20 @@ namespace GDModel
             }
         }
 
+        public int SourceCitationsCount
+        {
+            get { return fSourceCitations == null ? 0 : fSourceCitations.Count; }
+        }
+
         public GDMList<GDMSourceCitation> SourceCitations
         {
-            get { return fSourceCitations; }
+            get {
+                if (fSourceCitations == null) {
+                    fSourceCitations = new GDMList<GDMSourceCitation>();
+                }
+
+                return fSourceCitations;
+            }
         }
 
         public GDMList<GDMMultimediaLink> MultimediaLinks
@@ -132,7 +143,6 @@ namespace GDModel
         protected GDMCustomEvent()
         {
             fDate = new GDMDateValue();
-            fSourceCitations = new GDMList<GDMSourceCitation>();
             fMultimediaLinks = new GDMList<GDMMultimediaLink>();
         }
 
@@ -140,7 +150,7 @@ namespace GDModel
         {
             if (disposing) {
                 if (fNotes != null) fNotes.Dispose();
-                fSourceCitations.Dispose();
+                if (fSourceCitations != null) fSourceCitations.Dispose();
                 fMultimediaLinks.Dispose();
             }
             base.Dispose(disposing);
@@ -154,7 +164,7 @@ namespace GDModel
             fDate.TrimExcess();
             if (fPlace != null) fPlace.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
-            fSourceCitations.TrimExcess();
+            if (fSourceCitations != null) fSourceCitations.TrimExcess();
             fMultimediaLinks.TrimExcess();
         }
 
@@ -175,7 +185,7 @@ namespace GDModel
             fReligiousAffilation = sourceObj.fReligiousAffilation;
             fRestriction = sourceObj.fRestriction;
             if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
-            AssignList(sourceObj.SourceCitations, fSourceCitations);
+            if (sourceObj.fSourceCitations != null) AssignList(sourceObj.fSourceCitations, SourceCitations);
             AssignList(sourceObj.MultimediaLinks, fMultimediaLinks);
         }
 
@@ -192,7 +202,7 @@ namespace GDModel
             fReligiousAffilation = string.Empty;
             fRestriction = GDMRestriction.rnNone;
             if (fNotes != null) fNotes.Clear();
-            fSourceCitations.Clear();
+            if (fSourceCitations != null) fSourceCitations.Clear();
             fMultimediaLinks.Clear();
         }
 
@@ -201,7 +211,8 @@ namespace GDModel
             return base.IsEmpty() && (fAddress == null || fAddress.IsEmpty()) && string.IsNullOrEmpty(fAgency) && string.IsNullOrEmpty(fCause)
                 && string.IsNullOrEmpty(fClassification) && fDate.IsEmpty() && (fPlace == null || fPlace.IsEmpty())
                 && string.IsNullOrEmpty(fReligiousAffilation) && (fRestriction == GDMRestriction.rnNone)
-                && (fNotes == null || fNotes.Count == 0) && (fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
+                && (fNotes == null || fNotes.Count == 0)
+                && (fSourceCitations == null || fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
@@ -212,7 +223,7 @@ namespace GDModel
             fDate.ReplaceXRefs(map);
             if (fPlace != null) fPlace.ReplaceXRefs(map);
             if (fNotes != null) fNotes.ReplaceXRefs(map);
-            fSourceCitations.ReplaceXRefs(map);
+            if (fSourceCitations != null) fSourceCitations.ReplaceXRefs(map);
             fMultimediaLinks.ReplaceXRefs(map);
         }
 

--- a/projects/GKCore/GDModel/GDMCustomEvent.cs
+++ b/projects/GKCore/GDModel/GDMCustomEvent.cs
@@ -76,7 +76,13 @@ namespace GDModel
 
         public GDMPlace Place
         {
-            get { return fPlace; }
+            get {
+                if (fPlace == null) {
+                    fPlace = new GDMPlace();
+                }
+
+                return fPlace;
+            }
         }
 
         public string ReligiousAffilation
@@ -117,11 +123,15 @@ namespace GDModel
             get { return fMultimediaLinks; }
         }
 
+        public bool HasPlace
+        {
+            get { return fPlace != null && !fPlace.IsEmpty(); }
+        }
+
 
         protected GDMCustomEvent()
         {
             fDate = new GDMDateValue();
-            fPlace = new GDMPlace();
             fSourceCitations = new GDMList<GDMSourceCitation>();
             fMultimediaLinks = new GDMList<GDMMultimediaLink>();
         }
@@ -142,7 +152,7 @@ namespace GDModel
 
             if (fAddress != null) fAddress.TrimExcess();
             fDate.TrimExcess();
-            fPlace.TrimExcess();
+            if (fPlace != null) fPlace.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
             fSourceCitations.TrimExcess();
             fMultimediaLinks.TrimExcess();
@@ -161,7 +171,7 @@ namespace GDModel
             fCause = sourceObj.fCause;
             fClassification = sourceObj.fClassification;
             fDate.Assign(sourceObj.fDate);
-            fPlace.Assign(sourceObj.fPlace);
+            if (sourceObj.fPlace != null) Place.Assign(sourceObj.fPlace);
             fReligiousAffilation = sourceObj.fReligiousAffilation;
             fRestriction = sourceObj.fRestriction;
             if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
@@ -178,7 +188,7 @@ namespace GDModel
             fCause = string.Empty;
             fClassification = string.Empty;
             fDate.Clear();
-            fPlace.Clear();
+            if (fPlace != null) fPlace.Clear();
             fReligiousAffilation = string.Empty;
             fRestriction = GDMRestriction.rnNone;
             if (fNotes != null) fNotes.Clear();
@@ -189,7 +199,7 @@ namespace GDModel
         public override bool IsEmpty()
         {
             return base.IsEmpty() && (fAddress == null || fAddress.IsEmpty()) && string.IsNullOrEmpty(fAgency) && string.IsNullOrEmpty(fCause)
-                && string.IsNullOrEmpty(fClassification) && fDate.IsEmpty() && fPlace.IsEmpty()
+                && string.IsNullOrEmpty(fClassification) && fDate.IsEmpty() && (fPlace == null || fPlace.IsEmpty())
                 && string.IsNullOrEmpty(fReligiousAffilation) && (fRestriction == GDMRestriction.rnNone)
                 && (fNotes == null || fNotes.Count == 0) && (fSourceCitations.Count == 0) && (fMultimediaLinks.Count == 0);
         }
@@ -200,7 +210,7 @@ namespace GDModel
 
             if (fAddress != null) fAddress.ReplaceXRefs(map);
             fDate.ReplaceXRefs(map);
-            fPlace.ReplaceXRefs(map);
+            if (fPlace != null) fPlace.ReplaceXRefs(map);
             if (fNotes != null) fNotes.ReplaceXRefs(map);
             fSourceCitations.ReplaceXRefs(map);
             fMultimediaLinks.ReplaceXRefs(map);

--- a/projects/GKCore/GDModel/GDMIndividualRecord.cs
+++ b/projects/GKCore/GDModel/GDMIndividualRecord.cs
@@ -500,7 +500,7 @@ namespace GDModel
             if (mediaRec == null) return null;
             GDMMultimediaLink mmLink = null;
 
-            int num = MultimediaLinks.Count;
+            int num = MultimediaLinksCount;
             for (int i = 0; i < num; i++) {
                 GDMMultimediaLink lnk = MultimediaLinks[i];
 
@@ -522,7 +522,7 @@ namespace GDModel
         {
             GDMMultimediaLink result = null;
 
-            int num = MultimediaLinks.Count;
+            int num = MultimediaLinksCount;
             for (int i = 0; i < num; i++) {
                 GDMMultimediaLink mmLink = MultimediaLinks[i];
                 if (mmLink.IsPrimary) {

--- a/projects/GKCore/GDModel/GDMInterfaces.cs
+++ b/projects/GKCore/GDModel/GDMInterfaces.cs
@@ -79,6 +79,7 @@ namespace GDModel
 
     public interface IGDMStructWithSourceCitations : IGDMObject
     {
+        int SourceCitationsCount { get; }
         GDMList<GDMSourceCitation> SourceCitations { get; }
 
         //GDMSourceCitation AddSource(GDMSourceRecord sourceRec, string page, int quality);

--- a/projects/GKCore/GDModel/GDMInterfaces.cs
+++ b/projects/GKCore/GDModel/GDMInterfaces.cs
@@ -88,6 +88,7 @@ namespace GDModel
 
     public interface IGDMStructWithMultimediaLinks : IGDMObject
     {
+        int MultimediaLinksCount { get; }
         GDMList<GDMMultimediaLink> MultimediaLinks { get; }
 
         //GDMMultimediaLink AddMultimedia(GDMMultimediaRecord mediaRec);

--- a/projects/GKCore/GDModel/GDMInterfaces.cs
+++ b/projects/GKCore/GDModel/GDMInterfaces.cs
@@ -70,6 +70,7 @@ namespace GDModel
 
     public interface IGDMStructWithNotes : IGDMObject
     {
+        int NotesCount { get; }
         GDMList<GDMNotes> Notes { get; }
 
         //GDMNotes AddNote(GDMNoteRecord noteRec);

--- a/projects/GKCore/GDModel/GDMPersonalName.cs
+++ b/projects/GKCore/GDModel/GDMPersonalName.cs
@@ -108,9 +108,21 @@ namespace GDModel
             }
         }
 
+        public int SourceCitationsCount
+        {
+            get { return fSourceCitations == null ? 0 : fSourceCitations.Count; }
+        }
+
+
         public GDMList<GDMSourceCitation> SourceCitations
         {
-            get { return fSourceCitations; }
+            get {
+                if (fSourceCitations == null) {
+                    fSourceCitations = new GDMList<GDMSourceCitation>();
+                }
+
+                return fSourceCitations;
+            }
         }
 
 
@@ -123,7 +135,6 @@ namespace GDModel
             fLastPart = string.Empty;
 
             fPieces = new GDMPersonalNamePieces();
-            fSourceCitations = new GDMList<GDMSourceCitation>();
         }
 
         protected override void Dispose(bool disposing)
@@ -131,7 +142,7 @@ namespace GDModel
             if (disposing) {
                 fPieces.Dispose();
                 if (fNotes != null) fNotes.Dispose();
-                fSourceCitations.Dispose();
+                if (fSourceCitations != null) fSourceCitations.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -142,7 +153,7 @@ namespace GDModel
 
             fPieces.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
-            fSourceCitations.TrimExcess();
+            if (fSourceCitations != null) fSourceCitations.TrimExcess();
         }
 
         public override void Assign(GDMTag source)
@@ -162,7 +173,7 @@ namespace GDModel
 
             fPieces.Assign(otherName.Pieces);
             if (otherName.fNotes != null) AssignList(otherName.fNotes, Notes);
-            AssignList(otherName.SourceCitations, fSourceCitations);
+            if (otherName.fSourceCitations != null) AssignList(otherName.fSourceCitations, SourceCitations);
         }
 
         public override void Clear()
@@ -178,7 +189,7 @@ namespace GDModel
 
             fPieces.Clear();
             if (fNotes != null) fNotes.Clear();
-            fSourceCitations.Clear();
+            if (fSourceCitations != null) fSourceCitations.Clear();
         }
 
         public override bool IsEmpty()
@@ -186,7 +197,8 @@ namespace GDModel
             return base.IsEmpty()
                 && string.IsNullOrEmpty(fFirstPart) && string.IsNullOrEmpty(fSurname) && string.IsNullOrEmpty(fLastPart)
                 && fPieces.IsEmpty() && (fLanguage == GDMLanguageID.Unknown) && (fNameType == GDMNameType.ntNone)
-                && (fNotes == null || fNotes.Count == 0) && (fSourceCitations.Count == 0);
+                && (fNotes == null || fNotes.Count == 0)
+                && (fSourceCitations == null || fSourceCitations.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
@@ -195,7 +207,7 @@ namespace GDModel
 
             fPieces.ReplaceXRefs(map);
             if (fNotes != null) fNotes.ReplaceXRefs(map);
-            fSourceCitations.ReplaceXRefs(map);
+            if (fSourceCitations != null) fSourceCitations.ReplaceXRefs(map);
         }
 
         protected override string GetStringValue()

--- a/projects/GKCore/GDModel/GDMPersonalName.cs
+++ b/projects/GKCore/GDModel/GDMPersonalName.cs
@@ -92,9 +92,20 @@ namespace GDModel
             get { return fPieces; }
         }
 
+        public int NotesCount
+        {
+            get { return fNotes == null ? 0 : fNotes.Count; }
+        }
+
         public GDMList<GDMNotes> Notes
         {
-            get { return fNotes; }
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
         public GDMList<GDMSourceCitation> SourceCitations
@@ -112,7 +123,6 @@ namespace GDModel
             fLastPart = string.Empty;
 
             fPieces = new GDMPersonalNamePieces();
-            fNotes = new GDMList<GDMNotes>();
             fSourceCitations = new GDMList<GDMSourceCitation>();
         }
 
@@ -120,7 +130,7 @@ namespace GDModel
         {
             if (disposing) {
                 fPieces.Dispose();
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
                 fSourceCitations.Dispose();
             }
             base.Dispose(disposing);
@@ -131,7 +141,7 @@ namespace GDModel
             base.TrimExcess();
 
             fPieces.TrimExcess();
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
             fSourceCitations.TrimExcess();
         }
 
@@ -151,7 +161,7 @@ namespace GDModel
             fNameType = otherName.fNameType;
 
             fPieces.Assign(otherName.Pieces);
-            AssignList(otherName.Notes, fNotes);
+            if (otherName.fNotes != null) AssignList(otherName.fNotes, Notes);
             AssignList(otherName.SourceCitations, fSourceCitations);
         }
 
@@ -167,7 +177,7 @@ namespace GDModel
             fNameType = GDMNameType.ntNone;
 
             fPieces.Clear();
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
             fSourceCitations.Clear();
         }
 
@@ -176,7 +186,7 @@ namespace GDModel
             return base.IsEmpty()
                 && string.IsNullOrEmpty(fFirstPart) && string.IsNullOrEmpty(fSurname) && string.IsNullOrEmpty(fLastPart)
                 && fPieces.IsEmpty() && (fLanguage == GDMLanguageID.Unknown) && (fNameType == GDMNameType.ntNone)
-                && (fNotes.Count == 0) && (fSourceCitations.Count == 0);
+                && (fNotes == null || fNotes.Count == 0) && (fSourceCitations.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
@@ -184,7 +194,7 @@ namespace GDModel
             base.ReplaceXRefs(map);
 
             fPieces.ReplaceXRefs(map);
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
             fSourceCitations.ReplaceXRefs(map);
         }
 

--- a/projects/GKCore/GDModel/GDMPlace.cs
+++ b/projects/GKCore/GDModel/GDMPlace.cs
@@ -47,9 +47,20 @@ namespace GDModel
             get { return fMap; }
         }
 
+        public int NotesCount
+        {
+            get { return fNotes == null ? 0 : fNotes.Count; }
+        }
+
         public GDMList<GDMNotes> Notes
         {
-            get { return fNotes; }
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
 
@@ -60,7 +71,6 @@ namespace GDModel
             fForm = string.Empty;
             fLocation = new GDMPointer((int)GEDCOMTagType._LOC, string.Empty);
             fMap = new GDMMap();
-            fNotes = new GDMList<GDMNotes>();
         }
 
         public GDMPlace(int tagId, string tagValue) : this()
@@ -71,7 +81,7 @@ namespace GDModel
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -82,7 +92,7 @@ namespace GDModel
 
             fLocation.TrimExcess();
             fMap.TrimExcess();
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
         }
 
         public override void Assign(GDMTag source)
@@ -96,7 +106,7 @@ namespace GDModel
             fForm = otherPlace.fForm;
             fLocation.Assign(otherPlace.fLocation);
             fMap.Assign(otherPlace.fMap);
-            AssignList(otherPlace.Notes, fNotes);
+            if (otherPlace.fNotes != null) AssignList(otherPlace.fNotes, Notes);
         }
 
         public override void Clear()
@@ -106,12 +116,12 @@ namespace GDModel
             fForm = string.Empty;
             fLocation.Clear();
             fMap.Clear();
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
         }
 
         public override bool IsEmpty()
         {
-            return base.IsEmpty() && fLocation.IsEmpty() && fMap.IsEmpty() && string.IsNullOrEmpty(fForm) && (fNotes.Count == 0);
+            return base.IsEmpty() && fLocation.IsEmpty() && fMap.IsEmpty() && string.IsNullOrEmpty(fForm) && (fNotes == null || fNotes.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
@@ -119,7 +129,7 @@ namespace GDModel
             base.ReplaceXRefs(map);
             fLocation.ReplaceXRefs(map);
             fMap.ReplaceXRefs(map);
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
         }
     }
 }

--- a/projects/GKCore/GDModel/GDMPointerWithNotes.cs
+++ b/projects/GKCore/GDModel/GDMPointerWithNotes.cs
@@ -26,21 +26,26 @@ namespace GDModel
     {
         private GDMList<GDMNotes> fNotes;
 
-        public GDMList<GDMNotes> Notes
+        public int NotesCount
         {
-            get { return fNotes; }
+            get { return fNotes == null ? 0 : fNotes.Count; }
         }
 
-
-        public GDMPointerWithNotes()
+        public GDMList<GDMNotes> Notes
         {
-            fNotes = new GDMList<GDMNotes>();
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -49,7 +54,7 @@ namespace GDModel
         {
             base.TrimExcess();
 
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
         }
 
         public override void Assign(GDMTag source)
@@ -60,24 +65,24 @@ namespace GDModel
 
             base.Assign(source);
 
-            AssignList(sourceObj.fNotes, fNotes);
+            if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
         }
 
         public override void Clear()
         {
             base.Clear();
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
         }
 
         public override bool IsEmpty()
         {
-            return base.IsEmpty() && (fNotes.Count == 0);
+            return base.IsEmpty() && (fNotes == null || fNotes.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
         {
             base.ReplaceXRefs(map);
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
         }
     }
 }

--- a/projects/GKCore/GDModel/GDMRecord.cs
+++ b/projects/GKCore/GDModel/GDMRecord.cs
@@ -78,9 +78,20 @@ namespace GDModel
             get { return fMultimediaLinks; }
         }
 
+        public int NotesCount
+        {
+            get { return fNotes == null ? 0 : fNotes.Count; }
+        }
+
         public GDMList<GDMNotes> Notes
         {
-            get { return fNotes; }
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
         public GDMRecordType RecordType
@@ -120,7 +131,6 @@ namespace GDModel
             fXRef = string.Empty;
             fAutomatedRecordID = string.Empty;
             fChangeDate = new GDMChangeDate();
-            fNotes = new GDMList<GDMNotes>();
             fSourceCitations = new GDMList<GDMSourceCitation>();
             fMultimediaLinks = new GDMList<GDMMultimediaLink>();
             fUserReferences = new GDMList<GDMUserReference>();
@@ -129,7 +139,7 @@ namespace GDModel
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
                 fSourceCitations.Dispose();
                 fMultimediaLinks.Dispose();
                 fUserReferences.Dispose();
@@ -147,7 +157,7 @@ namespace GDModel
             base.TrimExcess();
 
             fChangeDate.TrimExcess();
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
             fSourceCitations.TrimExcess();
             fMultimediaLinks.TrimExcess();
             fUserReferences.TrimExcess();
@@ -175,7 +185,7 @@ namespace GDModel
 
             base.Assign(source);
 
-            AssignList(sourceRec.fNotes, fNotes);
+            if (sourceRec.fNotes != null) AssignList(sourceRec.fNotes, Notes);
             AssignList(sourceRec.fMultimediaLinks, fMultimediaLinks);
             AssignList(sourceRec.fSourceCitations, fSourceCitations);
             AssignList(sourceRec.fUserReferences, fUserReferences);
@@ -193,7 +203,7 @@ namespace GDModel
                 }
             }
 
-            while (fNotes.Count > 0) {
+            while (fNotes != null && fNotes.Count > 0) {
                 GDMTag tag = fNotes.Extract(0);
                 targetRecord.Notes.Add((GDMNotes)tag);
             }
@@ -218,7 +228,7 @@ namespace GDModel
         {
             base.ReplaceXRefs(map);
 
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
             fSourceCitations.ReplaceXRefs(map);
             fMultimediaLinks.ReplaceXRefs(map);
             fUserReferences.ReplaceXRefs(map);
@@ -230,7 +240,7 @@ namespace GDModel
 
             fAutomatedRecordID = string.Empty;
             fChangeDate.Clear();
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
             fSourceCitations.Clear();
             fMultimediaLinks.Clear();
             fUserReferences.Clear();
@@ -240,7 +250,8 @@ namespace GDModel
         public override bool IsEmpty()
         {
             return base.IsEmpty() && string.IsNullOrEmpty(fAutomatedRecordID) && fChangeDate.IsEmpty() &&
-                (fNotes.Count == 0) && (fSourceCitations.Count == 0) && 
+                (fNotes == null || fNotes.Count == 0) &&
+                (fSourceCitations.Count == 0) && 
                 (fMultimediaLinks.Count == 0) && (fUserReferences.Count == 0);
         }
 

--- a/projects/GKCore/GDModel/GDMRecord.cs
+++ b/projects/GKCore/GDModel/GDMRecord.cs
@@ -99,9 +99,20 @@ namespace GDModel
             get { return (GDMRecordType)base.Id; }
         }
 
+        public int SourceCitationsCount
+        {
+            get { return fSourceCitations == null ? 0 : fSourceCitations.Count; }
+        }
+
         public GDMList<GDMSourceCitation> SourceCitations
         {
-            get { return fSourceCitations; }
+            get {
+                if (fSourceCitations == null) {
+                    fSourceCitations = new GDMList<GDMSourceCitation>();
+                }
+
+                return fSourceCitations;
+            }
         }
 
         public string UID
@@ -131,7 +142,6 @@ namespace GDModel
             fXRef = string.Empty;
             fAutomatedRecordID = string.Empty;
             fChangeDate = new GDMChangeDate();
-            fSourceCitations = new GDMList<GDMSourceCitation>();
             fMultimediaLinks = new GDMList<GDMMultimediaLink>();
             fUserReferences = new GDMList<GDMUserReference>();
         }
@@ -140,7 +150,7 @@ namespace GDModel
         {
             if (disposing) {
                 if (fNotes != null) fNotes.Dispose();
-                fSourceCitations.Dispose();
+                if (fSourceCitations != null) fSourceCitations.Dispose();
                 fMultimediaLinks.Dispose();
                 fUserReferences.Dispose();
             }
@@ -158,14 +168,14 @@ namespace GDModel
 
             fChangeDate.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
-            fSourceCitations.TrimExcess();
+            if (fSourceCitations != null) fSourceCitations.TrimExcess();
             fMultimediaLinks.TrimExcess();
             fUserReferences.TrimExcess();
         }
 
         public int IndexOfSource(GDMSourceRecord sourceRec)
         {
-            if (sourceRec != null) {
+            if (sourceRec != null && fSourceCitations != null) {
                 int num = fSourceCitations.Count;
                 for (int i = 0; i < num; i++) {
                     if (fSourceCitations[i].XRef == sourceRec.XRef) {
@@ -187,7 +197,7 @@ namespace GDModel
 
             if (sourceRec.fNotes != null) AssignList(sourceRec.fNotes, Notes);
             AssignList(sourceRec.fMultimediaLinks, fMultimediaLinks);
-            AssignList(sourceRec.fSourceCitations, fSourceCitations);
+            if (sourceRec.fSourceCitations != null) AssignList(sourceRec.fSourceCitations, SourceCitations);
             AssignList(sourceRec.fUserReferences, fUserReferences);
         }
 
@@ -213,7 +223,7 @@ namespace GDModel
                 targetRecord.MultimediaLinks.Add((GDMMultimediaLink)tag);
             }
 
-            while (fSourceCitations.Count > 0) {
+            while (fSourceCitations != null && fSourceCitations.Count > 0) {
                 GDMTag tag = fSourceCitations.Extract(0);
                 targetRecord.SourceCitations.Add((GDMSourceCitation)tag);
             }
@@ -229,7 +239,7 @@ namespace GDModel
             base.ReplaceXRefs(map);
 
             if (fNotes != null) fNotes.ReplaceXRefs(map);
-            fSourceCitations.ReplaceXRefs(map);
+            if (fSourceCitations != null) fSourceCitations.ReplaceXRefs(map);
             fMultimediaLinks.ReplaceXRefs(map);
             fUserReferences.ReplaceXRefs(map);
         }
@@ -241,7 +251,7 @@ namespace GDModel
             fAutomatedRecordID = string.Empty;
             fChangeDate.Clear();
             if (fNotes != null) fNotes.Clear();
-            fSourceCitations.Clear();
+            if (fSourceCitations != null) fSourceCitations.Clear();
             fMultimediaLinks.Clear();
             fUserReferences.Clear();
             fUID = string.Empty;
@@ -251,7 +261,7 @@ namespace GDModel
         {
             return base.IsEmpty() && string.IsNullOrEmpty(fAutomatedRecordID) && fChangeDate.IsEmpty() &&
                 (fNotes == null || fNotes.Count == 0) &&
-                (fSourceCitations.Count == 0) && 
+                (fSourceCitations == null || fSourceCitations.Count == 0) && 
                 (fMultimediaLinks.Count == 0) && (fUserReferences.Count == 0);
         }
 

--- a/projects/GKCore/GDModel/GDMRecord.cs
+++ b/projects/GKCore/GDModel/GDMRecord.cs
@@ -73,9 +73,20 @@ namespace GDModel
             get { return fChangeDate; }
         }
 
+        public int MultimediaLinksCount
+        {
+            get { return fMultimediaLinks == null ? 0 : fMultimediaLinks.Count; }
+        }
+
         public GDMList<GDMMultimediaLink> MultimediaLinks
         {
-            get { return fMultimediaLinks; }
+            get {
+                if (fMultimediaLinks == null) {
+                    fMultimediaLinks = new GDMList<GDMMultimediaLink>();
+                }
+
+                return fMultimediaLinks;
+            }
         }
 
         public int NotesCount
@@ -142,7 +153,6 @@ namespace GDModel
             fXRef = string.Empty;
             fAutomatedRecordID = string.Empty;
             fChangeDate = new GDMChangeDate();
-            fMultimediaLinks = new GDMList<GDMMultimediaLink>();
             fUserReferences = new GDMList<GDMUserReference>();
         }
 
@@ -151,7 +161,7 @@ namespace GDModel
             if (disposing) {
                 if (fNotes != null) fNotes.Dispose();
                 if (fSourceCitations != null) fSourceCitations.Dispose();
-                fMultimediaLinks.Dispose();
+                if (fMultimediaLinks != null) fMultimediaLinks.Dispose();
                 fUserReferences.Dispose();
             }
             base.Dispose(disposing);
@@ -169,7 +179,7 @@ namespace GDModel
             fChangeDate.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
             if (fSourceCitations != null) fSourceCitations.TrimExcess();
-            fMultimediaLinks.TrimExcess();
+            if (fMultimediaLinks != null) fMultimediaLinks.TrimExcess();
             fUserReferences.TrimExcess();
         }
 
@@ -196,7 +206,7 @@ namespace GDModel
             base.Assign(source);
 
             if (sourceRec.fNotes != null) AssignList(sourceRec.fNotes, Notes);
-            AssignList(sourceRec.fMultimediaLinks, fMultimediaLinks);
+            if (sourceRec.fMultimediaLinks != null) AssignList(sourceRec.fMultimediaLinks, MultimediaLinks);
             if (sourceRec.fSourceCitations != null) AssignList(sourceRec.fSourceCitations, SourceCitations);
             AssignList(sourceRec.fUserReferences, fUserReferences);
         }
@@ -218,7 +228,7 @@ namespace GDModel
                 targetRecord.Notes.Add((GDMNotes)tag);
             }
 
-            while (fMultimediaLinks.Count > 0) {
+            while (fMultimediaLinks != null && fMultimediaLinks.Count > 0) {
                 GDMTag tag = fMultimediaLinks.Extract(0);
                 targetRecord.MultimediaLinks.Add((GDMMultimediaLink)tag);
             }
@@ -240,7 +250,7 @@ namespace GDModel
 
             if (fNotes != null) fNotes.ReplaceXRefs(map);
             if (fSourceCitations != null) fSourceCitations.ReplaceXRefs(map);
-            fMultimediaLinks.ReplaceXRefs(map);
+            if (fMultimediaLinks != null) fMultimediaLinks.ReplaceXRefs(map);
             fUserReferences.ReplaceXRefs(map);
         }
 
@@ -252,7 +262,7 @@ namespace GDModel
             fChangeDate.Clear();
             if (fNotes != null) fNotes.Clear();
             if (fSourceCitations != null) fSourceCitations.Clear();
-            fMultimediaLinks.Clear();
+            if (fMultimediaLinks != null) fMultimediaLinks.Clear();
             fUserReferences.Clear();
             fUID = string.Empty;
         }
@@ -262,7 +272,8 @@ namespace GDModel
             return base.IsEmpty() && string.IsNullOrEmpty(fAutomatedRecordID) && fChangeDate.IsEmpty() &&
                 (fNotes == null || fNotes.Count == 0) &&
                 (fSourceCitations == null || fSourceCitations.Count == 0) && 
-                (fMultimediaLinks.Count == 0) && (fUserReferences.Count == 0);
+                (fMultimediaLinks == null || fMultimediaLinks.Count == 0) &&
+                (fUserReferences.Count == 0);
         }
 
         public void SetXRef(GDMTree tree, string newXRef, bool removeOldXRef)

--- a/projects/GKCore/GDModel/GDMSourceCitation.cs
+++ b/projects/GKCore/GDModel/GDMSourceCitation.cs
@@ -66,9 +66,20 @@ namespace GDModel
             get { return fMultimediaLinks; }
         }
 
+        public int NotesCount
+        {
+            get { return fNotes == null ? 0 : fNotes.Count; }
+        }
+
         public GDMList<GDMNotes> Notes
         {
-            get { return fNotes; }
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
         public string Page
@@ -93,7 +104,6 @@ namespace GDModel
 
             fData = new GDMSourceCitationData();
             fText = new GDMTextTag((int)GEDCOMTagType.TEXT);
-            fNotes = new GDMList<GDMNotes>();
             fMultimediaLinks = new GDMList<GDMMultimediaLink>();
         }
 
@@ -102,7 +112,7 @@ namespace GDModel
             if (disposing) {
                 fData.Dispose();
                 fText.Dispose();
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
                 fMultimediaLinks.Dispose();
             }
             base.Dispose(disposing);
@@ -115,7 +125,7 @@ namespace GDModel
             fData.TrimExcess();
             fDescription.TrimExcess();
             fText.TrimExcess();
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
             fMultimediaLinks.TrimExcess();
         }
 
@@ -132,7 +142,7 @@ namespace GDModel
             fData.Assign(sourceObj.fData);
             fDescription.Assign(sourceObj.fDescription);
             fText.Assign(sourceObj.fText);
-            AssignList(sourceObj.Notes, fNotes);
+            if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
             AssignList(sourceObj.MultimediaLinks, fMultimediaLinks);
         }
 
@@ -145,7 +155,7 @@ namespace GDModel
             fDescription.Clear();
             fPage = string.Empty;
             fText.Clear();
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
             fMultimediaLinks.Clear();
         }
 
@@ -154,7 +164,7 @@ namespace GDModel
             bool result;
 
             bool isCommonEmpty = string.IsNullOrEmpty(fPage)
-                && (fNotes.Count == 0) && (fMultimediaLinks.Count == 0);
+                && (fNotes == null || fNotes.Count == 0) && (fMultimediaLinks.Count == 0);
 
             if (IsPointer) {
                 result = base.IsEmpty() && isCommonEmpty && fData.IsEmpty();
@@ -169,7 +179,7 @@ namespace GDModel
         {
             base.ReplaceXRefs(map);
 
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
             fMultimediaLinks.ReplaceXRefs(map);
         }
 

--- a/projects/GKCore/GDModel/GDMSourceCitation.cs
+++ b/projects/GKCore/GDModel/GDMSourceCitation.cs
@@ -61,9 +61,20 @@ namespace GDModel
             get { return fDescription; }
         }
 
+        public int MultimediaLinksCount
+        {
+            get { return fMultimediaLinks == null ? 0 : fMultimediaLinks.Count; }
+        }
+
         public GDMList<GDMMultimediaLink> MultimediaLinks
         {
-            get { return fMultimediaLinks; }
+            get {
+                if (fMultimediaLinks == null) {
+                    fMultimediaLinks = new GDMList<GDMMultimediaLink>();
+                }
+
+                return fMultimediaLinks;
+            }
         }
 
         public int NotesCount
@@ -104,7 +115,6 @@ namespace GDModel
 
             fData = new GDMSourceCitationData();
             fText = new GDMTextTag((int)GEDCOMTagType.TEXT);
-            fMultimediaLinks = new GDMList<GDMMultimediaLink>();
         }
 
         protected override void Dispose(bool disposing)
@@ -113,7 +123,7 @@ namespace GDModel
                 fData.Dispose();
                 fText.Dispose();
                 if (fNotes != null) fNotes.Dispose();
-                fMultimediaLinks.Dispose();
+                if (fMultimediaLinks != null) fMultimediaLinks.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -126,7 +136,7 @@ namespace GDModel
             fDescription.TrimExcess();
             fText.TrimExcess();
             if (fNotes != null) fNotes.TrimExcess();
-            fMultimediaLinks.TrimExcess();
+            if (fMultimediaLinks != null) fMultimediaLinks.TrimExcess();
         }
 
         public override void Assign(GDMTag source)
@@ -143,7 +153,7 @@ namespace GDModel
             fDescription.Assign(sourceObj.fDescription);
             fText.Assign(sourceObj.fText);
             if (sourceObj.fNotes != null) AssignList(sourceObj.fNotes, Notes);
-            AssignList(sourceObj.MultimediaLinks, fMultimediaLinks);
+            if (sourceObj.fMultimediaLinks != null) AssignList(sourceObj.fMultimediaLinks, MultimediaLinks);
         }
 
         public override void Clear()
@@ -156,7 +166,7 @@ namespace GDModel
             fPage = string.Empty;
             fText.Clear();
             if (fNotes != null) fNotes.Clear();
-            fMultimediaLinks.Clear();
+            if (fMultimediaLinks != null) fMultimediaLinks.Clear();
         }
 
         public override bool IsEmpty()
@@ -164,7 +174,8 @@ namespace GDModel
             bool result;
 
             bool isCommonEmpty = string.IsNullOrEmpty(fPage)
-                && (fNotes == null || fNotes.Count == 0) && (fMultimediaLinks.Count == 0);
+                && (fNotes == null || fNotes.Count == 0)
+                && (fMultimediaLinks == null || fMultimediaLinks.Count == 0);
 
             if (IsPointer) {
                 result = base.IsEmpty() && isCommonEmpty && fData.IsEmpty();
@@ -180,7 +191,7 @@ namespace GDModel
             base.ReplaceXRefs(map);
 
             if (fNotes != null) fNotes.ReplaceXRefs(map);
-            fMultimediaLinks.ReplaceXRefs(map);
+            if (fMultimediaLinks != null) fMultimediaLinks.ReplaceXRefs(map);
         }
 
         protected override string GetStringValue()

--- a/projects/GKCore/GDModel/GDMSourceData.cs
+++ b/projects/GKCore/GDModel/GDMSourceData.cs
@@ -40,9 +40,20 @@ namespace GDModel
             get { return fEvents; }
         }
 
+        public int NotesCount
+        {
+            get { return fNotes == null ? 0 : fNotes.Count; }
+        }
+
         public GDMList<GDMNotes> Notes
         {
-            get { return fNotes; }
+            get {
+                if (fNotes == null) {
+                    fNotes = new GDMList<GDMNotes>();
+                }
+
+                return fNotes;
+            }
         }
 
 
@@ -52,14 +63,13 @@ namespace GDModel
 
             fAgency = string.Empty;
             fEvents = new GDMList<GDMSourceEvent>();
-            fNotes = new GDMList<GDMNotes>();
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
                 fEvents.Dispose();
-                fNotes.Dispose();
+                if (fNotes != null) fNotes.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -69,7 +79,7 @@ namespace GDModel
             base.TrimExcess();
 
             fEvents.TrimExcess();
-            fNotes.TrimExcess();
+            if (fNotes != null) fNotes.TrimExcess();
         }
 
         public override void Clear()
@@ -77,19 +87,19 @@ namespace GDModel
             base.Clear();
             fAgency = string.Empty;
             fEvents.Clear();
-            fNotes.Clear();
+            if (fNotes != null) fNotes.Clear();
         }
 
         public override bool IsEmpty()
         {
-            return base.IsEmpty() && (fEvents.Count == 0) && string.IsNullOrEmpty(fAgency) && (fNotes.Count == 0);
+            return base.IsEmpty() && (fEvents.Count == 0) && string.IsNullOrEmpty(fAgency) && (fNotes == null || fNotes.Count == 0);
         }
 
         public override void ReplaceXRefs(GDMXRefReplacer map)
         {
             base.ReplaceXRefs(map);
             fEvents.ReplaceXRefs(map);
-            fNotes.ReplaceXRefs(map);
+            if (fNotes != null) fNotes.ReplaceXRefs(map);
         }
     }
 }

--- a/projects/GKCore/GDModel/GDMTree.cs
+++ b/projects/GKCore/GDModel/GDMTree.cs
@@ -574,7 +574,7 @@ namespace GDModel
             int num = fRecords.Count;
             for (int i = 0; i < num; i++) {
                 GDMRecord rec = fRecords[i];
-                for (int j = rec.MultimediaLinks.Count - 1; j >= 0; j--) {
+                for (int j = rec.MultimediaLinksCount - 1; j >= 0; j--) {
                     if (rec.MultimediaLinks[j].XRef == mRec.XRef) {
                         rec.MultimediaLinks.DeleteAt(j);
                     }

--- a/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
+++ b/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
@@ -129,7 +129,7 @@ namespace GDModel.Providers.GEDCOM
 
         private void CheckTagWithMultimediaLinks(IGDMStructWithMultimediaLinks tag)
         {
-            for (int i = tag.MultimediaLinks.Count - 1; i >= 0; i--) {
+            for (int i = tag.MultimediaLinksCount - 1; i >= 0; i--) {
                 GDMMultimediaLink mmLink = tag.MultimediaLinks[i];
                 if (!mmLink.IsPointer) {
                     TransformMultimediaLink(mmLink);

--- a/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
+++ b/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
@@ -103,7 +103,7 @@ namespace GDModel.Providers.GEDCOM
 
         private void CheckTagWithNotes(IGDMStructWithNotes tag)
         {
-            for (int i = tag.Notes.Count - 1; i >= 0; i--) {
+            for (int i = tag.NotesCount - 1; i >= 0; i--) {
                 GDMNotes note = tag.Notes[i];
                 if (!note.IsPointer) {
                     TransformNote(note);

--- a/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
+++ b/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
@@ -116,7 +116,7 @@ namespace GDModel.Providers.GEDCOM
 
         private void CheckTagWithSourceCitations(IGDMStructWithSourceCitations tag)
         {
-            for (int i = tag.SourceCitations.Count - 1; i >= 0; i--) {
+            for (int i = tag.SourceCitationsCount - 1; i >= 0; i--) {
                 GDMSourceCitation sourCit = tag.SourceCitations[i];
                 if (!sourCit.IsPointer) {
                     TransformSourceCitation(sourCit);

--- a/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
+++ b/projects/GKCore/GDModel/Providers/GEDCOM/GEDCOMChecker.cs
@@ -188,7 +188,9 @@ namespace GDModel.Providers.GEDCOM
                 }
             }
 
-            CheckEventPlace(evt.Place);
+            if (evt.HasPlace) {
+                CheckEventPlace(evt.Place);
+            }
         }
 
         private void CheckUserRef(GDMIndividualRecord iRec, GDMUserReference userRef)


### PR DESCRIPTION
`GDMCustomEvent` is the most populous object in the memory. Make it more lightweight.

The screenshot is a comparison between master and this branch of my main GEDCOM file

![image](https://user-images.githubusercontent.com/144791/115101630-5c90ab00-9f35-11eb-963c-093009c5057e.png)
