### PR TITLE
Fix ArgumentOutOfRangeException on empty list

### DIFF
--- a/projects/GKv3/GKComponents/GKUI/Components/GKListView.cs
+++ b/projects/GKv3/GKComponents/GKUI/Components/GKListView.cs
@@ -659,6 +659,10 @@ namespace GKUI.Components
 
         public GKListItem GetSelectedItem()
         {
+            if (SelectedRow < 0) {
+                return null;
+            }
+
             var item = SelectedItem as GKListItem;
             return item;
         }


### PR DESCRIPTION
Right click on empty grid view throws ArgumentOutOfRangeException on Mac.

The underlying issue is in Eto.Forms. Empty grid view return `new [] { -1 }` for `SelectedRows` on empty grid.