### PR TITLE
Reduce number of disposable classes

### DIFF
--- a/projects/GKCore/GKCore/BaseContext.cs
+++ b/projects/GKCore/GKCore/BaseContext.cs
@@ -54,7 +54,7 @@ namespace GKCore
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class BaseContext : BaseObject, IBaseContext
     {
@@ -171,7 +171,6 @@ namespace GKCore
         protected override void Dispose(bool disposing)
         {
             if (disposing) {
-                fUndoman.Dispose();
                 fTree.Dispose();
             }
             base.Dispose(disposing);
@@ -1631,7 +1630,7 @@ namespace GKCore
         /// <summary>
         /// This method performs a basic locking of the records for their
         /// editors.
-        /// 
+        ///
         /// The original idea was to call the methods Lock/Unlock records,
         /// in the edit dialogs of the records. However, it would be unsafe,
         /// because in the case of a failure of dialogue, the record would

--- a/projects/GKCore/GKCore/Charts/TreeChartModel.cs
+++ b/projects/GKCore/GKCore/Charts/TreeChartModel.cs
@@ -41,16 +41,6 @@ namespace GKCore.Charts
 
     public delegate void InfoRequestEventHandler(object sender, TreeChartPerson person);
 
-    /// <summary>
-    /// 
-    /// </summary>
-    public class PersonList : ExtList<TreeChartPerson>
-    {
-        public PersonList(bool ownsObjects) : base(ownsObjects)
-        {
-        }
-    }
-
     public enum TreeChartKind
     {
         ckAncestors,
@@ -59,7 +49,7 @@ namespace GKCore.Charts
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class TreeChartModel : ChartModel
     {
@@ -73,9 +63,9 @@ namespace GKCore.Charts
         public const int DEF_PERSON_NODE_PADDING = 10;
 
         private readonly ChartFilter fFilter;
-        private readonly PersonList fPersons;
-        private readonly IList<string> fPreparedFamilies;
-        private readonly IList<string> fPreparedIndividuals;
+        private readonly List<TreeChartPerson> fPersons;
+        private readonly List<string> fPreparedFamilies;
+        private readonly List<string> fPreparedIndividuals;
 
         private IBaseWindow fBase;
         private IFont fBoldFont;
@@ -218,7 +208,7 @@ namespace GKCore.Charts
             set { fPathDebug = value; }
         }
 
-        public PersonList Persons
+        public IList<TreeChartPerson> Persons
         {
             get { return fPersons; }
         }
@@ -261,7 +251,7 @@ namespace GKCore.Charts
             fFilter = new ChartFilter();
             fFilterData = new GKVarCache<GDMIndividualRecord, bool>();
             fGraph = null;
-            fPersons = new PersonList(true);
+            fPersons = new List<TreeChartPerson>();
             fPreparedFamilies = new List<string>();
             fPreparedIndividuals = new List<string>();
             fScale = 1.0f;
@@ -277,7 +267,6 @@ namespace GKCore.Charts
             if (disposing) {
                 if (fGraph != null) fGraph.Dispose();
                 fFilter.Dispose();
-                fPersons.Dispose();
 
                 DoneGraphics();
                 DoneSigns();
@@ -994,7 +983,7 @@ namespace GKCore.Charts
             return result;
         }
 
-        private void RecalcAnc(ExtList<TreeChartPerson> prev, TreeChartPerson person, int ptX, int ptY)
+        private void RecalcAnc(List<TreeChartPerson> prev, TreeChartPerson person, int ptX, int ptY)
         {
             if (person == null) return;
 
@@ -1059,12 +1048,8 @@ namespace GKCore.Charts
         {
             Array.Clear(fEdges, 0, fEdges.Length);
 
-            var prev = new ExtList<TreeChartPerson>();
-            try {
-                RecalcAnc(prev, fRoot, fMargins, fMargins);
-            } finally {
-                prev.Dispose();
-            }
+            var prev = new List<TreeChartPerson>();
+            RecalcAnc(prev, fRoot, fMargins, fMargins);
         }
 
         private bool ShiftDesc(TreeChartPerson person, int offset, bool isSingle, bool verify = false)
@@ -1155,10 +1140,10 @@ namespace GKCore.Charts
             }
 
             // This code is designed to align parents in the center of the location of children (across width),
-            // because in the process of drawing children, various kinds of displacement are formed, 
-            // and the initial arrangement of the parents can be very laterally, 
+            // because in the process of drawing children, various kinds of displacement are formed,
+            // and the initial arrangement of the parents can be very laterally,
             // after the formation of a complete tree of their descendants.
-            // However, this may be a problem (reason of #189) in the case if a shift initiated from descendants, 
+            // However, this may be a problem (reason of #189) in the case if a shift initiated from descendants,
             // must be performed to the left with an overlay on an already formed side branch.
 
             if (!fOptions.AutoAlign) {
@@ -1258,7 +1243,7 @@ namespace GKCore.Charts
                 fEdges[gen] = person.Rect.Right;
             }
 
-            // Fix of long-distance displacement of male nodes in the presence of more than 
+            // Fix of long-distance displacement of male nodes in the presence of more than
             // one marriage and a large tree of descendants from the first wife
             if (person.Sex == GDMSex.svMale && spousesCount >= 2) {
                 var firstWife = person.GetSpouse(0);

--- a/projects/GKCore/GKCore/Charts/TreeChartPerson.cs
+++ b/projects/GKCore/GKCore/Charts/TreeChartPerson.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using BSLib;
 using BSLib.DataViz.SmartGraph;
 using BSLib.Design.Graphics;
@@ -32,7 +33,7 @@ using BSDColors = BSLib.Design.BSDConsts.Colors;
 namespace GKCore.Charts
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class PersonModifyEventArgs : EventArgs
     {
@@ -55,9 +56,9 @@ namespace GKCore.Charts
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public class TreeChartPerson : BaseObject
+    public class TreeChartPerson
     {
         private readonly TreeChartModel fModel;
 
@@ -74,8 +75,8 @@ namespace GKCore.Charts
         private GDMIndividualRecord fRec;
         private EnumSet<SpecialUserRef> fSigns;
         private GDMSex fSex;
-        private PersonList fChilds;
-        private PersonList fSpouses;
+        private List<TreeChartPerson> fChilds;
+        private List<TreeChartPerson> fSpouses;
         private IImage fPortrait;
         private int fPortraitWidth;
 
@@ -204,18 +205,6 @@ namespace GKCore.Charts
             UserColor = null;
         }
 
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                // don't dispose portrait - he's from cache!
-                //if (fPortrait != null) fPortrait.Dispose();
-
-                if (fChilds != null) fChilds.Dispose();
-                if (fSpouses != null) fSpouses.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         public bool HasFlag(PersonFlag flag)
         {
             return fFlags.Contains(flag);
@@ -263,7 +252,7 @@ namespace GKCore.Charts
         {
             if (child == null) return;
 
-            if (fChilds == null) fChilds = new PersonList(false);
+            if (fChilds == null) fChilds = new List<TreeChartPerson>();
 
             fChilds.Add(child);
         }
@@ -272,7 +261,7 @@ namespace GKCore.Charts
         {
             if (spouse == null) return;
 
-            if (fSpouses == null) fSpouses = new PersonList(false);
+            if (fSpouses == null) fSpouses = new List<TreeChartPerson>();
 
             fSpouses.Add(spouse);
         }

--- a/projects/GKCore/GKCore/Controllers/MapsViewerWinController.cs
+++ b/projects/GKCore/GKCore/Controllers/MapsViewerWinController.cs
@@ -32,17 +32,17 @@ using GKCore.MVP.Views;
 namespace GKCore.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public sealed class MapsViewerWinController : FormController<IMapsViewerWin>
     {
-        private readonly ExtList<GeoPoint> fMapPoints;
+        private readonly List<GeoPoint> fMapPoints;
         private readonly List<GDMRecord> fSelectedPersons;
-        private readonly ExtList<MapPlace> fPlaces;
+        private readonly List<MapPlace> fPlaces;
 
         private ITVNode fBaseRoot;
 
-        public ExtList<MapPlace> Places
+        public IList<MapPlace> Places
         {
             get { return fPlaces; }
         }
@@ -54,8 +54,8 @@ namespace GKCore.Controllers
 
         public MapsViewerWinController(IMapsViewerWin view, List<GDMRecord> selectedPersons) : base(view)
         {
-            fMapPoints = new ExtList<GeoPoint>(true);
-            fPlaces = new ExtList<MapPlace>(true);
+            fMapPoints = new List<GeoPoint>();
+            fPlaces = new List<MapPlace>();
             fSelectedPersons = selectedPersons;
         }
 
@@ -210,7 +210,7 @@ namespace GKCore.Controllers
                     var placeRef = place.PlaceRefs[j];
                     GDMCustomEvent evt = placeRef.Event;
                     var evtType = evt.GetTagType();
-                    bool checkEventType = (condBirth && evtType == GEDCOMTagType.BIRT) || 
+                    bool checkEventType = (condBirth && evtType == GEDCOMTagType.BIRT) ||
                         (condDeath && evtType == GEDCOMTagType.DEAT) || (condResidence && evtType == GEDCOMTagType.RESI);
 
                     if ((ind != null && (placeRef.Owner == ind)) || checkEventType) {
@@ -221,7 +221,7 @@ namespace GKCore.Controllers
 
             if (ind != null) {
                 // sort points by date
-                fMapPoints.QuickSort(MapPointsCompare);
+                SortHelper.QuickSort(fMapPoints, MapPointsCompare);
             }
 
             PlacesLoader.CopyPoints(fView.MapBrowser, fMapPoints, ind != null);

--- a/projects/GKCore/GKCore/Controllers/PatriarchsSearchController.cs
+++ b/projects/GKCore/GKCore/Controllers/PatriarchsSearchController.cs
@@ -18,6 +18,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+using System.Collections.Generic;
 using BSLib;
 using GDModel;
 using GKCore.MVP;
@@ -28,7 +29,7 @@ using GKCore.Types;
 namespace GKCore.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class PatriarchsSearchController : DialogController<IPatriarchsSearchDlg>
     {
@@ -57,11 +58,11 @@ namespace GKCore.Controllers
         public void Search()
         {
             fView.PatriarchsList.BeginUpdate();
-            ExtList<PatriarchObj> lst = null;
+            IList<PatriarchObj> lst = null;
             try {
                 fView.PatriarchsList.ClearItems();
                 lst = PatriarchsMan.GetPatriarchsList(fBase.Context, (int)fView.MinGensNum.Value, !fView.WithoutDatesCheck.Checked);
-                lst.QuickSort(PatriarchsCompare);
+                SortHelper.QuickSort(lst, PatriarchsCompare);
 
                 int num = lst.Count;
                 for (int i = 0; i < num; i++) {
@@ -73,7 +74,6 @@ namespace GKCore.Controllers
                     });
                 }
             } finally {
-                if (lst != null) lst.Dispose();
                 fView.PatriarchsList.EndUpdate();
             }
         }

--- a/projects/GKCore/GKCore/Controllers/ScriptEditWinController.cs
+++ b/projects/GKCore/GKCore/Controllers/ScriptEditWinController.cs
@@ -27,7 +27,7 @@ using GKCore.MVP.Views;
 namespace GKCore.Controllers
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class ScriptEditWinController : DialogController<IScriptEditWin>
     {
@@ -81,9 +81,8 @@ namespace GKCore.Controllers
         {
             try {
                 fView.DebugOutput.Clear();
-                using (ScriptEngine scrEngine = new ScriptEngine()) {
-                    scrEngine.lua_run(fView.ScriptText.Text, fBase, fView.DebugOutput);
-                }
+                var scrEngine = new ScriptEngine();
+                scrEngine.lua_run(fView.ScriptText.Text, fBase, fView.DebugOutput);
             } catch (Exception ex) {
                 Logger.WriteError("ScriptEditWin.Run()", ex);
             }

--- a/projects/GKCore/GKCore/Export/PedigreeExporter.cs
+++ b/projects/GKCore/GKCore/Export/PedigreeExporter.cs
@@ -31,7 +31,7 @@ using GKCore.Types;
 namespace GKCore.Export
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public sealed class PedigreeExporter : ReportExporter
     {
@@ -86,7 +86,7 @@ namespace GKCore.Export
 
         private PedigreeFormat fFormat;
         private PedigreeKind fKind;
-        private ExtList<PedigreePerson> fPersonList;
+        private List<PedigreePerson> fPersonList;
         private readonly GDMIndividualRecord fRoot;
         private readonly ShieldState fShieldState;
         private StringList fSourceList;
@@ -215,58 +215,54 @@ namespace GKCore.Export
                 fWriter.AddParagraphLink(LangMan.LS(LSID.LSID_Mother) + ": " + GKUtils.GetNameString(mother, true, false) + " ", fTextFont, idLink(mother), fLinkFont);
             }
 
-            var evList = new ExtList<PedigreeEvent>(true);
-            try {
-                int i;
-                if (person.IRec.HasEvents) {
-                    fWriter.AddParagraph(LangMan.LS(LSID.LSID_Events) + ":", fTextFont);
+            var evList = new List<PedigreeEvent>();
+            int i;
+            if (person.IRec.HasEvents) {
+                fWriter.AddParagraph(LangMan.LS(LSID.LSID_Events) + ":", fTextFont);
 
-                    int num = person.IRec.Events.Count;
-                    for (i = 0; i < num; i++) {
-                        GDMCustomEvent evt = person.IRec.Events[i];
-                        if (!(evt is GDMIndividualAttribute) || fOptions.PedigreeOptions.IncludeAttributes) {
-                            evList.Add(new PedigreeEvent(person.IRec, evt));
-                        }
+                int num = person.IRec.Events.Count;
+                for (i = 0; i < num; i++) {
+                    GDMCustomEvent evt = person.IRec.Events[i];
+                    if (!(evt is GDMIndividualAttribute) || fOptions.PedigreeOptions.IncludeAttributes) {
+                        evList.Add(new PedigreeEvent(person.IRec, evt));
                     }
-                    WriteEventList(person, evList);
+                }
+                WriteEventList(person, evList);
+            }
+
+            int num2 = person.IRec.SpouseToFamilyLinks.Count;
+            for (i = 0; i < num2; i++) {
+                GDMFamilyRecord family = fTree.GetPtrValue(person.IRec.SpouseToFamilyLinks[i]);
+                if (!fBase.Context.IsRecordAccess(family.Restriction)) continue;
+
+                GDMIndividualRecord spRec;
+                string unk;
+                if (person.IRec.Sex == GDMSex.svMale) {
+                    spRec = fTree.GetPtrValue(family.Wife);
+                    st = LangMan.LS(LSID.LSID_Wife) + ": ";
+                    unk = LangMan.LS(LSID.LSID_UnkFemale);
+                } else {
+                    spRec = fTree.GetPtrValue(family.Husband);
+                    st = LangMan.LS(LSID.LSID_Husband) + ": ";
+                    unk = LangMan.LS(LSID.LSID_UnkMale);
                 }
 
-                int num2 = person.IRec.SpouseToFamilyLinks.Count;
-                for (i = 0; i < num2; i++) {
-                    GDMFamilyRecord family = fTree.GetPtrValue(person.IRec.SpouseToFamilyLinks[i]);
-                    if (!fBase.Context.IsRecordAccess(family.Restriction)) continue;
-
-                    GDMIndividualRecord spRec;
-                    string unk;
-                    if (person.IRec.Sex == GDMSex.svMale) {
-                        spRec = fTree.GetPtrValue(family.Wife);
-                        st = LangMan.LS(LSID.LSID_Wife) + ": ";
-                        unk = LangMan.LS(LSID.LSID_UnkFemale);
-                    } else {
-                        spRec = fTree.GetPtrValue(family.Husband);
-                        st = LangMan.LS(LSID.LSID_Husband) + ": ";
-                        unk = LangMan.LS(LSID.LSID_UnkMale);
-                    }
-
-                    string sps;
-                    if (spRec != null) {
-                        sps = st + GKUtils.GetNameString(spRec, true, false) + GKUtils.GetPedigreeLifeStr(spRec, fOptions.PedigreeOptions.Format)/* + this.idLink(this.FindPerson(irec))*/;
-                    } else {
-                        sps = st + unk;
-                    }
-
-                    fWriter.AddParagraph(sps, fTextFont);
-
-                    evList.Clear();
-                    int childrenCount = family.Children.Count;
-                    for (int j = 0; j < childrenCount; j++) {
-                        GDMIndividualRecord child = fTree.GetPtrValue(family.Children[j]);
-                        evList.Add(new PedigreeEvent(child, child.FindEvent(GEDCOMTagType.BIRT)));
-                    }
-                    WriteEventList(person, evList);
+                string sps;
+                if (spRec != null) {
+                    sps = st + GKUtils.GetNameString(spRec, true, false) + GKUtils.GetPedigreeLifeStr(spRec, fOptions.PedigreeOptions.Format)/* + this.idLink(this.FindPerson(irec))*/;
+                } else {
+                    sps = st + unk;
                 }
-            } finally {
-                evList.Dispose();
+
+                fWriter.AddParagraph(sps, fTextFont);
+
+                evList.Clear();
+                int childrenCount = family.Children.Count;
+                for (int j = 0; j < childrenCount; j++) {
+                    GDMIndividualRecord child = fTree.GetPtrValue(family.Children[j]);
+                    evList.Add(new PedigreeEvent(child, child.FindEvent(GEDCOMTagType.BIRT)));
+                }
+                WriteEventList(person, evList);
             }
 
             if (fOptions.PedigreeOptions.IncludeNotes && person.IRec.HasNotes) {
@@ -275,8 +271,8 @@ namespace GKCore.Export
                 fWriter.BeginList();
 
                 int notesCount = person.IRec.Notes.Count;
-                for (int i = 0; i < notesCount; i++) {
-                    GDMLines noteLines = fTree.GetNoteLines(person.IRec.Notes[i]);
+                for (int j = 0; j < notesCount; j++) {
+                    GDMLines noteLines = fTree.GetNoteLines(person.IRec.Notes[j]);
                     fWriter.AddListItem(" " + GKUtils.MergeStrings(noteLines), fTextFont);
                 }
 
@@ -334,9 +330,9 @@ namespace GKCore.Export
             return item1.Date.CompareTo(item2.Date);
         }
 
-        private void WriteEventList(PedigreePerson person, ExtList<PedigreeEvent> evList)
+        private void WriteEventList(PedigreePerson person, List<PedigreeEvent> evList)
         {
-            evList.QuickSort(EventsCompare);
+            SortHelper.QuickSort(evList, EventsCompare);
 
             int evtNum = evList.Count;
             for (int i = 0; i < evtNum; i++) {
@@ -345,9 +341,9 @@ namespace GKCore.Export
                     var evtType = evt.GetTagType();
 
                     if (evtType == GEDCOMTagType.BIRT) {
-                        evList.Exchange(i, 0);
+                        Exchange(evList, i, 0);
                     } else if (evtType == GEDCOMTagType.DEAT) {
-                        evList.Exchange(i, evtNum - 1);
+                        Exchange(evList, i, evtNum - 1);
                     }
                 }
             }
@@ -384,6 +380,13 @@ namespace GKCore.Export
             }
 
             fWriter.EndList();
+        }
+
+        private static void Exchange<T>(List<T> list, int index1, int index2)
+        {
+            var f = list[index1];
+            list[index1] = list[index2];
+            list[index2] = f;
         }
 
         private void GenStep(PedigreePerson parent, GDMIndividualRecord iRec, int level, int familyOrder)
@@ -455,7 +458,7 @@ namespace GKCore.Export
 
         private void ReIndex()
         {
-            fPersonList.QuickSort(PersonsCompare);
+            SortHelper.QuickSort(fPersonList, PersonsCompare);
 
             int num3 = fPersonList.Count;
             for (int i = 0; i < num3; i++) {
@@ -510,7 +513,7 @@ namespace GKCore.Export
 
             fWriter.AddParagraph(fTitle, fTitleFont, TextAlignment.taCenter);
 
-            fPersonList = new ExtList<PedigreePerson>(true);
+            fPersonList = new List<PedigreePerson>();
             fSourceList = new StringList();
             try {
                 GenStep(null, fRoot, 1, 1);
@@ -549,7 +552,6 @@ namespace GKCore.Export
                 }
             } finally {
                 fSourceList.Dispose();
-                fPersonList.Dispose();
             }
         }
     }

--- a/projects/GKCore/GKCore/Export/TreesAlbumExporter.cs
+++ b/projects/GKCore/GKCore/Export/TreesAlbumExporter.cs
@@ -36,7 +36,7 @@ namespace GKCore.Export
         private readonly List<IndiObj> fIndiQueue;
         private readonly StringList fProcessed;
 
-        private ExtList<PatriarchObj> fPatList;
+        private IList<PatriarchObj> fPatList;
         private ExtRectF fPageSize;
         private ChartRenderer fRenderer;
         private IFont fLinkFont;
@@ -91,7 +91,7 @@ namespace GKCore.Export
                 treeBox.Width = (int)pageWidth;
 
                 fPatList = PatriarchsMan.GetPatriarchsList(fBase.Context, 2, false);
-                fPatList.QuickSort(PatriarchsCompare);
+                SortHelper.QuickSort(fPatList, PatriarchsCompare);
 
                 int num = fPatList.Count;
                 for (int i = 0; i < num; i++) {

--- a/projects/GKCore/GKCore/Interfaces/IListManager.cs
+++ b/projects/GKCore/GKCore/Interfaces/IListManager.cs
@@ -32,7 +32,7 @@ namespace GKCore.Interfaces
     public delegate IListItem CreateListItemHandler(object itemValue, object data);
 
 
-    public interface IListSource : IDisposable
+    public interface IListSource
     {
         EnumSet<RecordAction> AllowedActions { get; }
         IBaseContext BaseContext { get; }

--- a/projects/GKCore/GKCore/Lists/ListManager.cs
+++ b/projects/GKCore/GKCore/Lists/ListManager.cs
@@ -36,9 +36,9 @@ using BSDColors = BSLib.Design.BSDConsts.Colors;
 namespace GKCore.Lists
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public abstract class ListSource : BaseObject, IListSource
+    public abstract class ListSource : IListSource
     {
         protected sealed class MapColumnRec
         {
@@ -111,7 +111,7 @@ namespace GKCore.Lists
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public abstract class ListManager : ListSource, IListManager
     {
@@ -186,14 +186,6 @@ namespace GKCore.Lists
             fRecordType = recordType;
 
             CreateFilter();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                // dummy
-            }
-            base.Dispose(disposing);
         }
 
         protected virtual void CreateFilter()
@@ -433,7 +425,7 @@ namespace GKCore.Lists
 
                 case DataType.dtGEDCOMDate:
                     return val.ToString();
-                    
+
                 default:
                     return val.ToString();
             }

--- a/projects/GKCore/GKCore/MVP/Controls/ControlHandlers.cs
+++ b/projects/GKCore/GKCore/MVP/Controls/ControlHandlers.cs
@@ -56,7 +56,7 @@ namespace GKCore.MVP.Controls
     {
         bool ShowPoints { get; set; }
         bool ShowLines { get; set; }
-        ExtList<GeoPoint> MapPoints { get; }
+        IList<GeoPoint> MapPoints { get; }
 
         int AddPoint(double latitude, double longitude, string hint);
         void ClearPoints();

--- a/projects/GKCore/GKCore/Maps/PlacesLoader.cs
+++ b/projects/GKCore/GKCore/Maps/PlacesLoader.cs
@@ -49,33 +49,25 @@ namespace GKCore.Maps
         public double MaxLat;
     }
 
-    public class MapPlace : BaseObject
+    public class MapPlace
     {
         public string Name;
         public readonly List<GeoPoint> Points;
-        public readonly ExtList<PlaceRef> PlaceRefs;
+        public readonly List<PlaceRef> PlaceRefs;
 
         public MapPlace()
         {
             Points = new List<GeoPoint>();
-            PlaceRefs = new ExtList<PlaceRef>(false);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                PlaceRefs.Dispose();
-            }
-            base.Dispose(disposing);
+            PlaceRefs = new List<PlaceRef>();
         }
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public static class PlacesLoader
     {
-        public static void AddPoint(ExtList<GeoPoint> mapPoints, GeoPoint gmPt, PlaceRef placeRef)
+        public static void AddPoint(IList<GeoPoint> mapPoints, GeoPoint gmPt, PlaceRef placeRef)
         {
             GeoPoint pt;
             int num = mapPoints.Count;
@@ -91,7 +83,7 @@ namespace GKCore.Maps
             mapPoints.Add(pt);
         }
 
-        public static void CopyPoints(IMapBrowser browser, ExtList<GeoPoint> gmapPoints, bool byPerson)
+        public static void CopyPoints(IMapBrowser browser, IList<GeoPoint> gmapPoints, bool byPerson)
         {
             if (gmapPoints == null)
                 throw new ArgumentNullException("gmapPoints");
@@ -117,7 +109,7 @@ namespace GKCore.Maps
             }
         }
 
-        public static CoordsRect GetPointsFrame(ExtList<GeoPoint> mapPoints)
+        public static CoordsRect GetPointsFrame(IList<GeoPoint> mapPoints)
         {
             CoordsRect result = new CoordsRect();
             if (mapPoints == null || mapPoints.Count <= 0) return result;

--- a/projects/GKCore/GKCore/Names/NamesTable.cs
+++ b/projects/GKCore/GKCore/Names/NamesTable.cs
@@ -29,23 +29,15 @@ using GKCore.Interfaces;
 namespace GKCore.Names
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public sealed class NamesTable : BaseObject, INamesTable
+    public sealed class NamesTable : INamesTable
     {
         private readonly Dictionary<string, NameEntry> fNames;
 
         public NamesTable()
         {
             fNames = new Dictionary<string, NameEntry>();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                // dummy
-            }
-            base.Dispose(disposing);
         }
 
         #region Internal functions

--- a/projects/GKCore/GKCore/Operations/UndoManager.cs
+++ b/projects/GKCore/GKCore/Operations/UndoManager.cs
@@ -34,7 +34,7 @@ namespace GKCore.Operations
 
     public delegate void TransactionEventHandler(object sender, TransactionType type);
 
-    public class UndoManager : BaseObject, IUndoManager
+    public class UndoManager : IUndoManager
     {
         private const CustomOperation TRANS_DELIMITER = null;
 
@@ -62,14 +62,6 @@ namespace GKCore.Operations
             fCurrentIndex = -1;
 
             PushInternal(TRANS_DELIMITER);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                // dummy
-            }
-            base.Dispose(disposing);
         }
 
         #region Private methods

--- a/projects/GKCore/GKCore/Options/GlobalOptions.cs
+++ b/projects/GKCore/GKCore/Options/GlobalOptions.cs
@@ -36,7 +36,7 @@ namespace GKCore.Options
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public sealed class GlobalOptions : BaseObject
     {
@@ -483,17 +483,11 @@ namespace GKCore.Options
         {
             if (disposing) {
                 fLastBases.Dispose();
-                //fLanguages.Dispose();
                 fRelations.Dispose();
 
                 fResidenceFilters.Dispose();
                 fNameFilters.Dispose();
-                //FMRUFiles.Dispose();
                 fEventFilters.Dispose();
-
-                fProxy.Dispose();
-                fPedigreeOptions.Dispose();
-                fTreeChartOptions.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/projects/GKCore/GKCore/Options/ListOptions.cs
+++ b/projects/GKCore/GKCore/Options/ListOptions.cs
@@ -33,9 +33,9 @@ namespace GKCore.Options
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public class ListOptions : BaseObject, IOptions
+    public class ListOptions : IOptions
     {
         public static readonly string[] RecordTypeNames = new string[] {
             "None",

--- a/projects/GKCore/GKCore/Options/PedigreeOptions.cs
+++ b/projects/GKCore/GKCore/Options/PedigreeOptions.cs
@@ -36,9 +36,9 @@ namespace GKCore.Options
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public sealed class PedigreeOptions : BaseObject, IOptions
+    public sealed class PedigreeOptions : IOptions
     {
         public PedigreeFormat Format;
         public bool IncludeAttributes;

--- a/projects/GKCore/GKCore/Options/ProxyOptions.cs
+++ b/projects/GKCore/GKCore/Options/ProxyOptions.cs
@@ -25,19 +25,15 @@ using GKCore.Interfaces;
 namespace GKCore.Options
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public sealed class ProxyOptions : BaseObject, IOptions
+    public sealed class ProxyOptions : IOptions
     {
         public string Server;
         public string Port;
         public string Login;
         public string Password;
         public bool UseProxy;
-
-        public ProxyOptions()
-        {
-        }
 
         public void Assign(IOptions source)
         {

--- a/projects/GKCore/GKCore/Options/TreeChartOptions.cs
+++ b/projects/GKCore/GKCore/Options/TreeChartOptions.cs
@@ -35,9 +35,9 @@ namespace GKCore.Options
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public sealed class TreeChartOptions : BaseObject, IOptions
+    public sealed class TreeChartOptions : IOptions
     {
         public static readonly int MALE_COLOR = -3750145; // FFC6C6FF
         public static readonly int FEMALE_COLOR = -14650; // FFFFC6C6

--- a/projects/GKCore/GKCore/ScriptEngine.cs
+++ b/projects/GKCore/GKCore/ScriptEngine.cs
@@ -55,21 +55,12 @@ namespace GKCore
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public class ScriptEngine : BaseObject
+    public class ScriptEngine
     {
         private ITextBox fDebugOutput;
         private IBaseWindow fBase;
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // dummy
-            }
-            base.Dispose(disposing);
-        }
 
         public void lua_run(string script, IBaseWindow baseWin, ITextBox debugOutput)
         {
@@ -560,7 +551,7 @@ namespace GKCore
         {
             GDMFamilyRecord fRec = familyPtr as GDMFamilyRecord;
             if (fRec == null) return;
-            
+
             GDMIndividualRecord spRec = spousePtr as GDMIndividualRecord;
             fRec.AddSpouse(spRec);
         }

--- a/projects/GKCore/GKCore/Tools/PlaceObj.cs
+++ b/projects/GKCore/GKCore/Tools/PlaceObj.cs
@@ -19,15 +19,14 @@
  */
 
 using System.Collections.Generic;
-using BSLib;
 using GDModel;
 
 namespace GKCore.Tools
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
-    public sealed class PlaceObj : BaseObject
+    public sealed class PlaceObj
     {
         public readonly string Name;
         public readonly List<GDMCustomEvent> Facts;
@@ -36,14 +35,6 @@ namespace GKCore.Tools
         {
             Name = name;
             Facts = new List<GDMCustomEvent>();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                // dummy
-            }
-            base.Dispose(disposing);
         }
     }
 }

--- a/projects/GKCore/GKCore/Tools/TreeTools.cs
+++ b/projects/GKCore/GKCore/Tools/TreeTools.cs
@@ -33,7 +33,7 @@ using GKCore.Types;
 namespace GKCore.Tools
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public static class TreeTools
     {
@@ -140,26 +140,23 @@ namespace GKCore.Tools
             string[] options = { "ratio=auto" };
             GraphvizWriter gvw = new GraphvizWriter("Family Tree", options);
 
-            using (ExtList<PatriarchObj> patList = PatriarchsMan.GetPatriarchsLinks(baseWin.Context, minGens, false, loneSuppress))
-            {
-                int num = patList.Count;
-                for (int i = 0; i < num; i++) {
-                    PatriarchObj pObj = patList[i];
+            var patList = PatriarchsMan.GetPatriarchsLinks(baseWin.Context, minGens, false, loneSuppress);
+            int num = patList.Count;
+            for (int i = 0; i < num; i++) {
+                PatriarchObj pObj = patList[i];
 
-                    if (!loneSuppress || pObj.HasLinks) {
-                        string color = (pObj.IRec.Sex == GDMSex.svFemale) ? "pink" : "blue";
-                        gvw.WriteNode(pObj.IRec.XRef, GKUtils.GetNameString(pObj.IRec, true, false), "filled", color, "box");
-                    }
+                if (!loneSuppress || pObj.HasLinks) {
+                    string color = (pObj.IRec.Sex == GDMSex.svFemale) ? "pink" : "blue";
+                    gvw.WriteNode(pObj.IRec.XRef, GKUtils.GetNameString(pObj.IRec, true, false), "filled", color, "box");
                 }
+            }
+            for (int i = 0; i < num; i++) {
+                PatriarchObj pat1 = patList[i];
 
-                for (int i = 0; i < num; i++) {
-                    PatriarchObj pat1 = patList[i];
-
-                    int num2 = pat1.Links.Count;
-                    for (int k = 0; k < num2; k++) {
-                        PatriarchObj pat2 = pat1.Links[k];
-                        gvw.WriteEdge(pat1.IRec.XRef, pat2.IRec.XRef);
-                    }
+                int num2 = pat1.Links.Count;
+                for (int k = 0; k < num2; k++) {
+                    PatriarchObj pat2 = pat1.Links[k];
+                    gvw.WriteEdge(pat1.IRec.XRef, pat2.IRec.XRef);
                 }
             }
 
@@ -1177,7 +1174,7 @@ namespace GKCore.Tools
             }
 
             result.Sort(new IndividualRecordComparer());
-            
+
             progress.ProgressDone();
 
             return result;
@@ -1273,8 +1270,8 @@ namespace GKCore.Tools
                 for (int i = 0; i < mainCount; i++) {
                     GDMIndividualRecord iRec = mainTree[i] as GDMIndividualRecord;
                     if (iRec != null) {
-                        int idx = names.AddObject(GKUtils.GetNameString(iRec, true, false), new ExtList<GDMIndividualRecord>());
-                        ((ExtList<GDMIndividualRecord>)names.GetObject(idx)).Add(iRec);
+                        int idx = names.AddObject(GKUtils.GetNameString(iRec, true, false), new List<GDMIndividualRecord>());
+                        ((IList<GDMIndividualRecord>)names.GetObject(idx)).Add(iRec);
 
                         var parts = GKUtils.GetNameParts(mainTree, iRec);
                         fams.AddObject(context.Culture.NormalizeSurname(parts.Surname, iRec.Sex == GDMSex.svFemale), null);
@@ -1288,7 +1285,7 @@ namespace GKCore.Tools
                         string tm = GKUtils.GetNameString(iRec, true, false);
                         int idx = names.IndexOf(tm);
                         if (idx >= 0) {
-                            ((ExtList<GDMIndividualRecord>)names.GetObject(idx)).Add(iRec);
+                            ((IList<GDMIndividualRecord>)names.GetObject(idx)).Add(iRec);
                         }
 
                         var parts = GKUtils.GetNameParts(tempTree, iRec);
@@ -1306,10 +1303,9 @@ namespace GKCore.Tools
                 }
 
                 for (int i = names.Count - 1; i >= 0; i--) {
-                    ExtList<GDMIndividualRecord> lst = (ExtList<GDMIndividualRecord>)names.GetObject(i);
+                    var lst = (IList<GDMIndividualRecord>)names.GetObject(i);
 
                     if (lst.Count == 1) {
-                        lst.Dispose();
                         names.Delete(i);
                     }
                 }
@@ -1327,7 +1323,7 @@ namespace GKCore.Tools
                     logBox.AppendText(LangMan.LS(LSID.LSID_SimilarNames) + CRLF);
                     for (int i = 0; i < namesCount; i++) {
                         logBox.AppendText("    " + names[i] + CRLF);
-                        ExtList<GDMIndividualRecord> lst = (ExtList<GDMIndividualRecord>)names.GetObject(i);
+                        var lst = (IList<GDMIndividualRecord>) names.GetObject(i);
 
                         int num5 = lst.Count;
                         for (int j = 0; j < num5; j++) {
@@ -1361,7 +1357,6 @@ namespace GKCore.Tools
             if (placesList == null)
                 throw new ArgumentNullException("placesList");
 
-            for (int i = placesList.Count - 1; i >= 0; i--) ((PlaceObj)placesList.GetObject(i)).Dispose();
             placesList.Clear();
         }
 

--- a/projects/GKCore/GKCore/Types/PatriarchObj.cs
+++ b/projects/GKCore/GKCore/Types/PatriarchObj.cs
@@ -19,12 +19,11 @@
  */
 
 using System.Collections.Generic;
-using BSLib;
 using GDModel;
 
 namespace GKCore.Types
 {
-    public sealed class PatriarchObj : BaseObject
+    public sealed class PatriarchObj
     {
         public GDMIndividualRecord IRec;
         public int BirthYear;

--- a/projects/GKTests/GKCore/BaseContextTests.cs
+++ b/projects/GKTests/GKCore/BaseContextTests.cs
@@ -108,7 +108,7 @@ namespace GKCore
         public void Test_CreateEventEx()
         {
             GDMIndividualRecord iRec = fContext.Tree.XRefIndex_Find("I1") as GDMIndividualRecord;
-            
+
             var evt = fContext.CreateEventEx(iRec, GEDCOMTagName.FACT, "17 JAN 2013", "Ivanovo");
             Assert.IsNotNull(evt);
 
@@ -405,23 +405,22 @@ namespace GKCore
         [Test]
         public void Test_UndoManager()
         {
-            using (var undoman = new UndoManager()) {
-                Assert.IsNotNull(undoman);
+            var undoman = new UndoManager();
+            Assert.IsNotNull(undoman);
 
-                Assert.IsFalse(undoman.CanUndo());
-                Assert.IsFalse(undoman.CanRedo());
+            Assert.IsFalse(undoman.CanUndo());
+            Assert.IsFalse(undoman.CanRedo());
 
-                undoman.Clear();
+            undoman.Clear();
 
-                Assert.IsFalse(undoman.DoOperation(null));
+            Assert.IsFalse(undoman.DoOperation(null));
 
-                undoman.Undo();
-                undoman.Redo();
-                undoman.Commit();
-                undoman.Rollback();
+            undoman.Undo();
+            undoman.Redo();
+            undoman.Commit();
+            undoman.Rollback();
 
-                Assert.IsFalse(undoman.DoOperation(new InvalidOperation(undoman)));
-            }
+            Assert.IsFalse(undoman.DoOperation(new InvalidOperation(undoman)));
         }
 
         [Test]

--- a/projects/GKTests/GKCore/CoreTests.cs
+++ b/projects/GKTests/GKCore/CoreTests.cs
@@ -279,7 +279,7 @@ namespace GKCore
 
                 navStack.Current = test;
                 navStack.Current = test2;
-                
+
                 Assert.AreEqual(test, navStack.Back());
                 Assert.AreEqual(test2, navStack.Next());
             }
@@ -288,68 +288,66 @@ namespace GKCore
         [Test]
         public void Test_NamesTable()
         {
-            using (NamesTable namesTable = new NamesTable())
-            {
-                Assert.IsNotNull(namesTable);
-                
-                NameEntry nameEntry = namesTable.AddName("Ivan");
-                Assert.IsNotNull(nameEntry);
-                Assert.AreEqual("Ivan", nameEntry.Name);
+            var namesTable = new NamesTable();
+            Assert.IsNotNull(namesTable);
 
-                nameEntry = namesTable.FindName("Ivan");
-                Assert.IsNotNull(nameEntry);
+            NameEntry nameEntry = namesTable.AddName("Ivan");
+            Assert.IsNotNull(nameEntry);
+            Assert.AreEqual("Ivan", nameEntry.Name);
 
-                string pat = namesTable.GetPatronymicByName("Ivan", GDMSex.svMale);
-                Assert.IsNull(pat);
+            nameEntry = namesTable.FindName("Ivan");
+            Assert.IsNotNull(nameEntry);
 
-                string name = namesTable.GetNameByPatronymic("Ivanovich");
-                Assert.AreEqual("", name);
+            string pat = namesTable.GetPatronymicByName("Ivan", GDMSex.svMale);
+            Assert.IsNull(pat);
 
-                GDMSex sex = namesTable.GetSexByName("Ivan");
-                Assert.AreEqual(GDMSex.svUnknown, sex);
-                
-                namesTable.SetName("Ivan", "Ivanovich", GDMSex.svMale);
-                namesTable.SetName("Ivan", "Ivanovna", GDMSex.svFemale);
+            string name = namesTable.GetNameByPatronymic("Ivanovich");
+            Assert.AreEqual("", name);
 
-                pat = namesTable.GetPatronymicByName("Ivan", GDMSex.svMale);
-                Assert.AreEqual("Ivanovich", pat);
+            GDMSex sex = namesTable.GetSexByName("Ivan");
+            Assert.AreEqual(GDMSex.svUnknown, sex);
 
-                pat = namesTable.GetPatronymicByName("Ivan", GDMSex.svFemale);
-                Assert.AreEqual("Ivanovna", pat);
+            namesTable.SetName("Ivan", "Ivanovich", GDMSex.svMale);
+            namesTable.SetName("Ivan", "Ivanovna", GDMSex.svFemale);
 
-                name = namesTable.GetNameByPatronymic("Ivanovich");
-                Assert.AreEqual("Ivan", name);
+            pat = namesTable.GetPatronymicByName("Ivan", GDMSex.svMale);
+            Assert.AreEqual("Ivanovich", pat);
 
-                name = namesTable.GetNameByPatronymic("Ivanovna");
-                Assert.AreEqual("Ivan", name);
+            pat = namesTable.GetPatronymicByName("Ivan", GDMSex.svFemale);
+            Assert.AreEqual("Ivanovna", pat);
 
-                namesTable.SetNameSex("Maria", GDMSex.svFemale);
-                sex = namesTable.GetSexByName("Maria");
-                Assert.AreEqual(GDMSex.svFemale, sex);
+            name = namesTable.GetNameByPatronymic("Ivanovich");
+            Assert.AreEqual("Ivan", name);
 
-                namesTable.SetName("", "", GDMSex.svUnknown);
-                namesTable.SetNameSex("", GDMSex.svUnknown);
+            name = namesTable.GetNameByPatronymic("Ivanovna");
+            Assert.AreEqual("Ivan", name);
 
-                namesTable.SetName("Anna", "Ivanovna", GDMSex.svFemale);
-                sex = namesTable.GetSexByName("Anna");
-                Assert.AreEqual(GDMSex.svFemale, sex);
+            namesTable.SetNameSex("Maria", GDMSex.svFemale);
+            sex = namesTable.GetSexByName("Maria");
+            Assert.AreEqual(GDMSex.svFemale, sex);
 
-                GDMIndividualRecord iRec = fContext.Tree.XRefIndex_Find("I3") as GDMIndividualRecord;
-                Assert.IsNotNull(iRec);
-                namesTable.ImportNames(fContext, iRec);
+            namesTable.SetName("", "", GDMSex.svUnknown);
+            namesTable.SetNameSex("", GDMSex.svUnknown);
 
-                namesTable.ImportNames(null, null);
+            namesTable.SetName("Anna", "Ivanovna", GDMSex.svFemale);
+            sex = namesTable.GetSexByName("Anna");
+            Assert.AreEqual(GDMSex.svFemale, sex);
 
-                sex = namesTable.GetSexByName("Anna");
-                Assert.AreEqual(GDMSex.svFemale, sex);
+            GDMIndividualRecord iRec = fContext.Tree.XRefIndex_Find("I3") as GDMIndividualRecord;
+            Assert.IsNotNull(iRec);
+            namesTable.ImportNames(fContext, iRec);
 
-                string namesFile = TestUtils.GetTempFilePath("names.txt");
-                try {
-                    namesTable.SaveToFile(namesFile);
-                    namesTable.LoadFromFile(namesFile);
-                } finally {
-                    TestUtils.RemoveTestFile(namesFile);
-                }
+            namesTable.ImportNames(null, null);
+
+            sex = namesTable.GetSexByName("Anna");
+            Assert.AreEqual(GDMSex.svFemale, sex);
+
+            string namesFile = TestUtils.GetTempFilePath("names.txt");
+            try {
+                namesTable.SaveToFile(namesFile);
+                namesTable.LoadFromFile(namesFile);
+            } finally {
+                TestUtils.RemoveTestFile(namesFile);
             }
         }
 
@@ -380,9 +378,8 @@ namespace GKCore
         [Test]
         public void Test_LuaScripts()
         {
-            using (ScriptEngine script = new ScriptEngine()) {
-                script.lua_run("gk_print(\"Hello\")", null, null);
-            }
+            var script = new ScriptEngine();
+            script.lua_run("gk_print(\"Hello\")", null, null);
         }
 
         [Test]

--- a/projects/GKTests/GKCore/PlacesLoaderTests.cs
+++ b/projects/GKTests/GKCore/PlacesLoaderTests.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using BSLib;
+using System.Collections.Generic;
 using GKCore.Maps;
 using GKCore.MVP.Controls;
 using NSubstitute;
@@ -47,11 +47,10 @@ namespace GKCore
         [Test]
         public void Test_MapPlace()
         {
-            using (var mapPlace = new MapPlace()) {
-                Assert.IsNotNull(mapPlace);
-                Assert.IsNotNull(mapPlace.Points);
-                Assert.IsNotNull(mapPlace.PlaceRefs);
-            }
+            var mapPlace = new MapPlace();
+            Assert.IsNotNull(mapPlace);
+            Assert.IsNotNull(mapPlace.Points);
+            Assert.IsNotNull(mapPlace.PlaceRefs);
         }
 
         [Test]
@@ -102,7 +101,7 @@ namespace GKCore
         [Test]
         public void Test_AddPoint()
         {
-            var gmapPoints = new ExtList<GeoPoint>();
+            var gmapPoints = new List<GeoPoint>();
 
             PlacesLoader.AddPoint(gmapPoints, new GeoPoint(0, 0, "test"), new PlaceRef(null, null));
             Assert.AreEqual(1, gmapPoints.Count);
@@ -118,7 +117,7 @@ namespace GKCore
 
             Assert.Throws(typeof(ArgumentNullException), () => { PlacesLoader.CopyPoints(mapBrowser, null, true); });
 
-            var gmapPoints = new ExtList<GeoPoint>();
+            var gmapPoints = new List<GeoPoint>();
             gmapPoints.Add(new GeoPoint(0, 0, "test"));
             PlacesLoader.CopyPoints(mapBrowser, gmapPoints, true);
         }
@@ -126,13 +125,13 @@ namespace GKCore
         [Test]
         public void Test_GetPointsFrame()
         {
-            CoordsRect coordsRect = PlacesLoader.GetPointsFrame(null);
+            var coordsRect = PlacesLoader.GetPointsFrame(null);
             Assert.AreEqual(0.0d, coordsRect.MinLon);
             Assert.AreEqual(0.0d, coordsRect.MinLat);
             Assert.AreEqual(0.0d, coordsRect.MaxLon);
             Assert.AreEqual(0.0d, coordsRect.MaxLat);
 
-            ExtList<GeoPoint> mapPoints = new ExtList<GeoPoint>();
+            var mapPoints = new List<GeoPoint>();
             mapPoints.Add(new GeoPoint(11, 13, "pt1"));
             mapPoints.Add(new GeoPoint(22, 25, "pt1"));
             coordsRect = PlacesLoader.GetPointsFrame(mapPoints);

--- a/projects/GKTests/GKCore/TreeChartTests.cs
+++ b/projects/GKTests/GKCore/TreeChartTests.cs
@@ -67,94 +67,86 @@ namespace GKCore
         }
 
         [Test]
-        public void Test_PersonList()
-        {
-            PersonList personList = new PersonList(true);
-            Assert.IsNotNull(personList);
-        }
-
-        [Test]
         public void Test_TreeChartPerson()
         {
-            using (TreeChartPerson tcPerson = new TreeChartPerson(null)) {
-                Assert.IsNotNull(tcPerson);
+            var tcPerson = new TreeChartPerson(null);
+            Assert.IsNotNull(tcPerson);
 
-                tcPerson.BuildBy(null);
+            tcPerson.BuildBy(null);
 
-                Assert.AreEqual(null, tcPerson.Rec);
+            Assert.AreEqual(null, tcPerson.Rec);
 
-                Assert.AreEqual(null, tcPerson.Portrait);
-                Assert.AreEqual(0, tcPerson.PortraitWidth);
+            Assert.AreEqual(null, tcPerson.Portrait);
+            Assert.AreEqual(0, tcPerson.PortraitWidth);
 
-                tcPerson.SetFlag(PersonFlag.pfDivorced, false);
-                Assert.AreEqual(false, tcPerson.HasFlag(PersonFlag.pfDivorced));
-                tcPerson.SetFlag(PersonFlag.pfDivorced, true);
-                Assert.AreEqual(true, tcPerson.HasFlag(PersonFlag.pfDivorced));
+            tcPerson.SetFlag(PersonFlag.pfDivorced, false);
+            Assert.AreEqual(false, tcPerson.HasFlag(PersonFlag.pfDivorced));
+            tcPerson.SetFlag(PersonFlag.pfDivorced, true);
+            Assert.AreEqual(true, tcPerson.HasFlag(PersonFlag.pfDivorced));
 
-                tcPerson.IsDup = false;
-                Assert.AreEqual(false, tcPerson.IsDup);
-                tcPerson.IsDup = true;
-                Assert.AreEqual(true, tcPerson.IsDup);
+            tcPerson.IsDup = false;
+            Assert.AreEqual(false, tcPerson.IsDup);
+            tcPerson.IsDup = true;
+            Assert.AreEqual(true, tcPerson.IsDup);
 
-                Assert.AreEqual(0, tcPerson.Height);
-                Assert.AreEqual(0, tcPerson.Width);
+            Assert.AreEqual(0, tcPerson.Height);
+            Assert.AreEqual(0, tcPerson.Width);
 
-                Assert.AreEqual(0, tcPerson.PtX);
-                tcPerson.PtX = 11;
-                Assert.AreEqual(11, tcPerson.PtX);
+            Assert.AreEqual(0, tcPerson.PtX);
+            tcPerson.PtX = 11;
+            Assert.AreEqual(11, tcPerson.PtX);
 
-                Assert.AreEqual(0, tcPerson.PtY);
-                tcPerson.PtY = 22;
-                Assert.AreEqual(22, tcPerson.PtY);
+            Assert.AreEqual(0, tcPerson.PtY);
+            tcPerson.PtY = 22;
+            Assert.AreEqual(22, tcPerson.PtY);
 
-                tcPerson.Selected = false;
-                Assert.AreEqual(false, tcPerson.Selected);
-                tcPerson.Selected = true;
-                Assert.AreEqual(true, tcPerson.Selected);
+            tcPerson.Selected = false;
+            Assert.AreEqual(false, tcPerson.Selected);
+            tcPerson.Selected = true;
+            Assert.AreEqual(true, tcPerson.Selected);
 
-                Assert.AreEqual(GDMSex.svUnknown, tcPerson.Sex);
-                tcPerson.Sex = GDMSex.svMale;
-                Assert.AreEqual(GDMSex.svMale, tcPerson.Sex);
+            Assert.AreEqual(GDMSex.svUnknown, tcPerson.Sex);
+            tcPerson.Sex = GDMSex.svMale;
+            Assert.AreEqual(GDMSex.svMale, tcPerson.Sex);
 
-                EnumSet<SpecialUserRef> enums = tcPerson.Signs;
-                Assert.IsTrue(enums.IsEmpty());
+            EnumSet<SpecialUserRef> enums = tcPerson.Signs;
+            Assert.IsTrue(enums.IsEmpty());
 
-                Assert.AreEqual(0, tcPerson.GetChildsCount());
-                Assert.AreEqual(0, tcPerson.GetSpousesCount());
+            Assert.AreEqual(0, tcPerson.GetChildsCount());
+            Assert.AreEqual(0, tcPerson.GetSpousesCount());
 
-                TreeChartPerson child = new TreeChartPerson(null);
-                tcPerson.AddChild(null);
-                tcPerson.AddChild(child);
-                Assert.AreEqual(1, tcPerson.GetChildsCount());
-                Assert.AreEqual(child, tcPerson.GetChild(0));
+            TreeChartPerson child = new TreeChartPerson(null);
+            tcPerson.AddChild(null);
+            tcPerson.AddChild(child);
+            Assert.AreEqual(1, tcPerson.GetChildsCount());
+            Assert.AreEqual(child, tcPerson.GetChild(0));
 
-                TreeChartPerson spouse = new TreeChartPerson(null);
-                tcPerson.AddSpouse(null);
-                tcPerson.AddSpouse(spouse);
-                Assert.AreEqual(1, tcPerson.GetSpousesCount());
-                Assert.AreEqual(spouse, tcPerson.GetSpouse(0));
+            TreeChartPerson spouse = new TreeChartPerson(null);
+            tcPerson.AddSpouse(null);
+            tcPerson.AddSpouse(spouse);
+            Assert.AreEqual(1, tcPerson.GetSpousesCount());
+            Assert.AreEqual(spouse, tcPerson.GetSpouse(0));
 
-                Assert.IsFalse(tcPerson.HasFlag(PersonFlag.pfDescWalk));
-                tcPerson.SetFlag(PersonFlag.pfDescWalk);
-                Assert.IsTrue(tcPerson.HasFlag(PersonFlag.pfDescWalk));
+            Assert.IsFalse(tcPerson.HasFlag(PersonFlag.pfDescWalk));
+            tcPerson.SetFlag(PersonFlag.pfDescWalk);
+            Assert.IsTrue(tcPerson.HasFlag(PersonFlag.pfDescWalk));
 
-                tcPerson.BuildBy(null);
+            tcPerson.BuildBy(null);
 
-                ExtRect psnRt = tcPerson.Rect;
-                Assert.IsTrue(psnRt.IsEmpty());
+            ExtRect psnRt = tcPerson.Rect;
+            Assert.IsTrue(psnRt.IsEmpty());
 
-                tcPerson.Sex = GDMSex.svMale;
-                var color = ((ColorHandler)tcPerson.GetSelectedColor()).Handle;
-                Assert.AreEqual(Color.FromArgb(255, Color.Blue), color);
+            tcPerson.Sex = GDMSex.svMale;
+            var color = ((ColorHandler) tcPerson.GetSelectedColor()).Handle;
+            Assert.AreEqual(Color.FromArgb(255, Color.Blue), color);
 
-                tcPerson.Sex = GDMSex.svFemale;
-                color = ((ColorHandler)tcPerson.GetSelectedColor()).Handle;
-                Assert.AreEqual(Color.FromArgb(255, Color.Red), color);
+            tcPerson.Sex = GDMSex.svFemale;
+            color = ((ColorHandler) tcPerson.GetSelectedColor()).Handle;
+            Assert.AreEqual(Color.FromArgb(255, Color.Red), color);
 
-                tcPerson.Sex = GDMSex.svUnknown;
-                color = ((ColorHandler)tcPerson.GetSelectedColor()).Handle;
-                Assert.AreEqual(Color.FromArgb(255, Color.Black), color);
-            }
+            tcPerson.Sex = GDMSex.svUnknown;
+            color = ((ColorHandler) tcPerson.GetSelectedColor()).Handle;
+            Assert.AreEqual(Color.FromArgb(255, Color.Black), color);
         }
 
         [Test]

--- a/projects/GKTests/GKCore/TreeToolsTests.cs
+++ b/projects/GKTests/GKCore/TreeToolsTests.cs
@@ -195,9 +195,6 @@ namespace GKCore
             Assert.IsNotNull(placeObj);
             Assert.AreEqual(null, placeObj.Name);
             Assert.IsNotNull(placeObj.Facts);
-
-            placeObj.Dispose();
-            Assert.IsNotNull(placeObj);
         }
 
         private static bool WalkProc(GDMIndividualRecord iRec, TreeTools.TreeWalkMode mode, object extData)

--- a/projects/GKTests/UITests/CommonFilterDlgTests.cs
+++ b/projects/GKTests/UITests/CommonFilterDlgTests.cs
@@ -33,7 +33,7 @@ using NUnit.Framework;
 namespace GKUI.Forms
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [TestFixture]
     public class CommonFilterDlgTests : CustomWindowTest
@@ -59,7 +59,6 @@ namespace GKUI.Forms
         public override void TearDown()
         {
             fDialog.Dispose();
-            fListMan.Dispose();
         }
 
         [Test]

--- a/projects/GKTests/UITests/PersonsFilterDlgTests.cs
+++ b/projects/GKTests/UITests/PersonsFilterDlgTests.cs
@@ -32,7 +32,7 @@ using NUnit.Extensions.Forms;
 namespace GKUI.Forms
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [TestFixture]
     public class PersonsFilterDlgTests : CustomWindowTest
@@ -56,7 +56,6 @@ namespace GKUI.Forms
         public override void TearDown()
         {
             fDialog.Dispose();
-            fListMan.Dispose();
         }
 
         [Test]

--- a/projects/GKv2/GKComponents/GKUI/Components/GKListView.cs
+++ b/projects/GKv2/GKComponents/GKUI/Components/GKListView.cs
@@ -41,7 +41,7 @@ using WFSortOrder = System.Windows.Forms.SortOrder;
 namespace GKUI.Components
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [Serializable]
     public class GKListItem : ListViewItem, IListItem
@@ -266,8 +266,6 @@ namespace GKUI.Components
             }
             set {
                 if (fListMan != value) {
-                    if (fListMan != null) fListMan.Dispose();
-
                     fListMan = value;
 
                     if (fListMan != null) {
@@ -316,17 +314,6 @@ namespace GKUI.Components
             ListViewItemSorter = fColumnSorter;
 
             fListMan = null;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing) {
-                if (fListMan != null) {
-                    fListMan.Dispose();
-                    fListMan = null;
-                }
-            }
-            base.Dispose(disposing);
         }
 
         public void Activate()

--- a/projects/GKv2/GKComponents/GKUI/Components/GKMapBrowser.cs
+++ b/projects/GKv2/GKComponents/GKUI/Components/GKMapBrowser.cs
@@ -34,11 +34,11 @@ using GKMap.WinForms;
 namespace GKUI.Components
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public sealed class GKMapBrowser : UserControl, IMapBrowser
     {
-        private readonly ExtList<GeoPoint> fMapPoints;
+        private readonly List<GeoPoint> fMapPoints;
         private bool fShowPoints;
         private bool fShowLines;
         private int fUpdateCount;
@@ -66,7 +66,7 @@ namespace GKUI.Components
             }
         }
 
-        public ExtList<GeoPoint> MapPoints
+        public IList<GeoPoint> MapPoints
         {
             get { return fMapPoints; }
         }
@@ -75,7 +75,7 @@ namespace GKUI.Components
         {
             InitControl();
 
-            fMapPoints = new ExtList<GeoPoint>(true);
+            fMapPoints = new List<GeoPoint>();
             fUpdateCount = 0;
             fShowPoints = true;
             fShowLines = true;
@@ -85,7 +85,6 @@ namespace GKUI.Components
         {
             if (disposing) {
                 ClearPoints();
-                fMapPoints.Dispose();
             }
             base.Dispose(disposing);
         }
@@ -99,7 +98,8 @@ namespace GKUI.Components
         {
             BeginUpdate();
             GeoPoint pt = new GeoPoint(latitude, longitude, hint);
-            int res = fMapPoints.Add(pt);
+            int res = fMapPoints.Count;
+            fMapPoints.Add(pt);
             EndUpdate();
 
             return res;
@@ -113,7 +113,7 @@ namespace GKUI.Components
 
         public void DeletePoint(int index)
         {
-            fMapPoints.Delete(index);
+            fMapPoints.RemoveAt(index);
             RefreshPoints();
         }
 
@@ -227,7 +227,7 @@ namespace GKUI.Components
                 fMapControl.MaxZoom = 24;
                 fMapControl.Zoom = 9;
 
-                // add custom layers  
+                // add custom layers
                 fMapControl.Overlays.Add(fObjects);
                 fMapControl.Overlays.Add(fTopOverlay);
 

--- a/projects/GKv2/GKTreeVizPlugin/TreeVizControl.cs
+++ b/projects/GKv2/GKTreeVizPlugin/TreeVizControl.cs
@@ -423,24 +423,21 @@ namespace GKTreeVizPlugin
                 fSys.SetViewSize(50, 50);
                 fSys.OnStop += OnArborStop;
 
-                using (ExtList<PatriarchObj> patList = PatriarchsMan.GetPatriarchsLinks(
-                                                           baseWin.Context, minGens, false, loneSuppress)) {
-                    int num = patList.Count;
-                    for (int i = 0; i < num; i++) {
-                        PatriarchObj pObj = patList[i];
+                var patList = PatriarchsMan.GetPatriarchsLinks(baseWin.Context, minGens, false, loneSuppress);
+                int num = patList.Count;
+                for (int i = 0; i < num; i++) {
+                    PatriarchObj pObj = patList[i];
 
-                        if (!loneSuppress || pObj.HasLinks) {
-                            ArborNode node = fSys.AddNode(pObj.IRec.XRef);
-                            node.Data = pObj;
-                        }
+                    if (!loneSuppress || pObj.HasLinks) {
+                        ArborNode node = fSys.AddNode(pObj.IRec.XRef);
+                        node.Data = pObj;
                     }
+                }
+                for (int i = 0; i < num; i++) {
+                    PatriarchObj pat1 = patList[i];
 
-                    for (int i = 0; i < num; i++) {
-                        PatriarchObj pat1 = patList[i];
-
-                        foreach (PatriarchObj pat2 in pat1.Links) {
-                            fSys.AddEdge(pat1.IRec.XRef, pat2.IRec.XRef);
-                        }
+                    foreach (PatriarchObj pat2 in pat1.Links) {
+                        fSys.AddEdge(pat1.IRec.XRef, pat2.IRec.XRef);
                     }
                 }
 


### PR DESCRIPTION
This PR removes excessive usage of `BaseObject` and `ExtList<T>` classes.

### What is `BaseObject`? 

`BaseObject` is an implementation of a generic disposable object pattern.

### What is `ExtList<T>`?

`ExtList<T>` is a wrapper around `List<T>` that is calling `IDisposable.Dispose` on list items when:

1. the item is `IDisposable`; and
2. the `ExtList<T>` is an "owner" of the items (`OwnsObjects` is true).

So, when an item is not `IDisposable` and list does not own its items then this is equivalent to `List<T>` plus some extra helper methods.

### What's been removed?

1. Inheritance of `BaseObject` when subclass does not override `protected virtual Dispose(bool dispose)` of `BaseObject`; or
2. when subclass have empty override of `Dispose`; or
3. subclasses that received empty override of `Dispose` as a result of the refactoring.