### PR TITLE
GKv3: Fix initial rendering of tree chart

### DIFF
--- a/projects/GKv3/GKComponents/GKUI/Components/ScrollablePanel.cs
+++ b/projects/GKv3/GKComponents/GKUI/Components/ScrollablePanel.cs
@@ -241,6 +241,16 @@ namespace GKUI.Components
             base.OnMouseWheel(e);
         }
 
+        protected override void OnShown(EventArgs e)
+        {
+            if (Loaded) {
+                fViewport = VisibleRect;
+                UpdateProperties();
+            }
+
+            base.OnShown(e);
+        }
+
         protected override void OnSizeChanged(EventArgs e)
         {
             if (Loaded) {


### PR DESCRIPTION
Problem: on first load tree chart is blank

### Why it happens? 

Because `VisibleRect` is `{0, 0, 0, 0}` on initial `OnSizeChanged` or `OnLoad`, `OnLoadCompleted`, etc, this is likely due to fact that at that time the chart control is not yet visible. Probably this is specific to MacOS. 