### PR TITLE
GKv3: Fix compatibility issues for GKMap on MacOS

### DIFF
--- a/projects/GKMap/GKMap.Core/GKMap.Core.nstd.csproj
+++ b/projects/GKMap/GKMap.Core/GKMap.Core.nstd.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
         <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
+        <PackageReference Include="System.Security.Principal.Windows" Version="4.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/projects/GKMap/GKMap.Core/GMaps.cs
+++ b/projects/GKMap/GKMap.Core/GMaps.cs
@@ -137,7 +137,7 @@ namespace GKMap
             }
         }
 
-        private static readonly SHA1CryptoServiceProvider HashProvider = new SHA1CryptoServiceProvider();
+        private static readonly SHA1 HashProvider = SHA1.Create();
 
         private static void ConvertToHash(ref string s)
         {

--- a/projects/GKMap/GKMap.Core/MapProviders/GMapProvider.cs
+++ b/projects/GKMap/GKMap.Core/MapProviders/GMapProvider.cs
@@ -100,8 +100,8 @@ namespace GKMap.MapProviders
 
         protected GMapProvider()
         {
-            using (var HashProvider = new SHA1CryptoServiceProvider()) {
-                DbId = Math.Abs(BitConverter.ToInt32(HashProvider.ComputeHash(Id.ToByteArray()), 0));
+            using (var sha1 = SHA1.Create()) {
+                DbId = Math.Abs(BitConverter.ToInt32(sha1.ComputeHash(Id.ToByteArray()), 0));
             }
 
             if (MapProviders.Exists(p => p.Id == Id || p.DbId == DbId)) {
@@ -148,7 +148,7 @@ namespace GKMap.MapProviders
         /// <summary>
         /// Gets or sets the value of the User-agent HTTP header.
         /// It's pseudo-randomized to avoid blockages...
-        /// </summary>                                
+        /// </summary>
         public static string UserAgent = string.Format("Mozilla/5.0 (Windows NT {1}.0; {2}rv:{0}.0) Gecko/20100101 Firefox/{0}.0",
             Stuff.Random.Next(DateTime.Today.Year - 1969 - 5, DateTime.Today.Year - 1969),
             Stuff.Random.Next(0, 10) % 2 == 0 ? 10 : 6,

--- a/projects/GKMap/GKMap.Core/MapProviders/GMapProviders.cs
+++ b/projects/GKMap/GKMap.Core/MapProviders/GMapProviders.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using GKMap.MapProviders.Bing;
 using GKMap.MapProviders.Etc;
@@ -57,7 +58,11 @@ namespace GKMap.MapProviders
 
         static GMapProviders()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Ssl3 | (SecurityProtocolType)3072;
+            try {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Ssl3 | (SecurityProtocolType) 3072;
+            } catch (NotSupportedException ex) {
+                Debug.WriteLine("GMapProviders: " + ex);
+            }
 
             fList = new List<GMapProvider>();
 

--- a/projects/GKMap/GKMap.Core/Stuff.cs
+++ b/projects/GKMap/GKMap.Core/Stuff.cs
@@ -85,11 +85,11 @@ namespace GKMap
         {
             byte[] results;
 
-            using (var hashProvider = new SHA1CryptoServiceProvider()) {
+            using (var hashProvider = SHA1.Create()) {
                 byte[] tdesKey = hashProvider.ComputeHash(Encoding.UTF8.GetBytes(passphrase));
                 Array.Resize(ref tdesKey, 16);
 
-                using (TripleDESCryptoServiceProvider tdesAlgorithm = new TripleDESCryptoServiceProvider()) {
+                using (var tdesAlgorithm = TripleDES.Create()) {
                     tdesAlgorithm.Key = tdesKey;
                     tdesAlgorithm.Mode = CipherMode.ECB;
                     tdesAlgorithm.Padding = PaddingMode.PKCS7;
@@ -117,12 +117,12 @@ namespace GKMap
         {
             byte[] results;
 
-            using (var hashProvider = new SHA1CryptoServiceProvider()) {
+            using (var hashProvider = SHA1.Create()) {
                 byte[] tdesKey = hashProvider.ComputeHash(Encoding.UTF8.GetBytes(passphrase));
                 Array.Resize(ref tdesKey, 16);
 
                 // Step 2. Create a new TripleDESCryptoServiceProvider object
-                using (TripleDESCryptoServiceProvider tdesAlgorithm = new TripleDESCryptoServiceProvider()) {
+                using (var tdesAlgorithm = TripleDES.Create()) {
                     // Step 3. Setup the decoder
                     tdesAlgorithm.Key = tdesKey;
                     tdesAlgorithm.Mode = CipherMode.ECB;
@@ -159,8 +159,6 @@ namespace GKMap
         {
             bool isSystem = false;
 
-            // FIXME
-#if !NETSTANDARD
             try {
                 using (var identity = System.Security.Principal.WindowsIdentity.GetCurrent()) {
                     isSystem = identity.IsSystem;
@@ -168,7 +166,6 @@ namespace GKMap
             } catch (Exception ex) {
                 Trace.WriteLine("SQLitePureImageCache, WindowsIdentity.GetCurrent: " + ex);
             }
-#endif
 
             var specFolder = (isSystem) ? Environment.SpecialFolder.CommonApplicationData : Environment.SpecialFolder.LocalApplicationData;
             string path = Environment.GetFolderPath(specFolder);

--- a/projects/GKv3/GEDKeeper3/GKUI/Forms/LocationEditDlg.design.cs
+++ b/projects/GKv3/GEDKeeper3/GKUI/Forms/LocationEditDlg.design.cs
@@ -76,6 +76,7 @@ namespace GKUI.Forms
             btnShowOnMap.Click += btnShowOnMap_Click;
 
             panMap = new Panel();
+            panMap.Size = new Size(768, 283);
             //panMap.BorderStyle = BorderStyle.Fixed3D;
 
             grpSearch = new GroupBox();


### PR DESCRIPTION
- `XXXCryptoServiceProvider` should not be used directly, `XXX.Create()` should be used instead.
- Guard `FileStream.Lock` & `FileStream.Unlock` are not supported on MacOS
- Guard `ServicePointManager.SecurityProtocol` with `NotSupportedException` (SSL3 is not supported & not allowed anymore)
- Set size to map panel