### PR TITLE
GKv3: Make ordinary columns sortable by default

### DIFF
--- a/projects/GKv3/GKComponents/GKUI/Components/GKListView.cs
+++ b/projects/GKv3/GKComponents/GKUI/Components/GKListView.cs
@@ -271,7 +271,7 @@ namespace GKUI.Components
             BeginUpdate();
             try {
                 int columnIndex = this.Columns.IndexOf(e.Column);
-                SetSortColumn(columnIndex, false);
+                SetSortColumn(columnIndex);
             } finally {
                 EndUpdate();
             }
@@ -512,6 +512,7 @@ namespace GKUI.Components
             column.DataCell = cell;
             column.AutoSize = autoSize;
             column.Width = width;
+            column.Sortable = true;
             Columns.Add(column);
         }
 


### PR DESCRIPTION
Since 2.5 columns are not sortable by default (see https://github.com/picoe/Eto/issues/894, https://github.com/picoe/Eto/pull/1030)