### PR TITLE
Build GKv3 installer (DMG) for MacOS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -25,3 +25,6 @@ csharp_new_line_before_finally = false
 [*.{md,yml}]
 indent_style = space
 indent_size = 2
+
+[*.sh]
+end_of_line = lf

--- a/.github/workflows/package-mac.yml
+++ b/.github/workflows/package-mac.yml
@@ -1,0 +1,28 @@
+name: Package GEDKeeper3 for MacOS
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  mac:
+
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Build
+      run: dotnet build -c MacOS_Debug -p:EnableDmgBuild=true
+      working-directory: projects/GKv3
+    - name: Upload DMG file
+      uses: actions/upload-artifact@v3
+      with:
+        name: GEDKeeper3
+        path: projects/GKv3/GEDKeeper3/bin/MacOS_Debug/*.dmg
+        if-no-files-found: error

--- a/build_v3.mac.sh
+++ b/build_v3.mac.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+dotnet build projects/GKv3/GEDKeeper3.sln -c MacOS_Debug -p:MacBuildBundle=true
+
+# For details how to create a proper DMG HSF+ file see here: https://stackoverflow.com/a/7553878/259946.
+# The ISO9660/HFS is a supported format for DMG files and can be treated as uncompressed DMG.
+
+# sudo apt install mkisofs
+cd projects/GKv3/GEDKeeper3/bin/MacOS_Debug
+mkisofs -V GEDKeeper -D -R -apple -no-pad -o GEDKeeper3-x64.dmg osx-x64
+mkisofs -V GEDKeeper -D -R -apple -no-pad -o GEDKeeper3-arm64.dmg osx-arm64
+cd -

--- a/projects/GKv3/.run/GEDKeeper3.Mac.run.xml
+++ b/projects/GKv3/.run/GEDKeeper3.Mac.run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="GEDKeeper3.Mac" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/GEDKeeper3/bin/MacOS_Debug/net6.0/GEDKeeper3.app/Contents/MacOS/GEDKeeper3" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/GEDKeeper3/bin/MacOS_Debug/GEDKeeper3.app/Contents/MacOS/GEDKeeper3" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GEDKeeper3/bin/MacOS_Debug/net6.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/GEDKeeper3/bin/MacOS_Debug/" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />


### PR DESCRIPTION
Added a GitHub action that produces DMG installer containing unified (x64/arm64) build of the GEDKeeper3, that should run on both x64 (I've checked it works) and arm64 (Apple Silicon M1/M2 - I unfortunately do not have one, so could not check).

Because the DMG file are unsigned after download when it is tried to be opened it produces the "App Is Damaged and Can’t Be Opened" warning. See [here](https://www.howtogeek.com/803598/app-is-damaged-and-cant-be-opened/) for the information why this is happening and how to fix it.

TL;DR; Removed the `com.apple.quarantine` attribute after installation:

`xattr -d com.apple.quarantine /Applications/GEDKeeper3.app`