### PR TITLE
More convenient output of Relationship calculator.

### DIFF
--- a/projects/GKCore/GKCore/Controllers/RelationshipCalculatorDlgController.cs
+++ b/projects/GKCore/GKCore/Controllers/RelationshipCalculatorDlgController.cs
@@ -75,8 +75,8 @@ namespace GKCore.Controllers
                     } else if (kinsGraph.FindVertex(fRec2.XRef) == null) {
                         fResult = "These individuals have no common relatives.";
                     } else {
-                        kinsGraph.SetTreeRoot(fRec1);
-                        fResult = kinsGraph.GetRelationship(fRec2, true, GlobalOptions.Instance.ShortKinshipForm);
+                        kinsGraph.SetTreeRoot(fRec2);
+                        fResult = kinsGraph.GetRelationship(fRec1, true, GlobalOptions.Instance.ShortKinshipForm);
                     }
                 }
             }

--- a/projects/GKCore/GKCore/Kinships/KinshipsGraph.cs
+++ b/projects/GKCore/GKCore/Kinships/KinshipsGraph.cs
@@ -103,9 +103,11 @@ namespace GKCore.Kinships
                 int great = 0;
                 int degree = 0;
                 GDMIndividualRecord src = null, tgt = null, prev_tgt = null;
-                string part, fullRel = "";
+                string relPart = "";
 
                 GDMIndividualRecord starting = null;
+
+                System.Collections.Generic.Stack<string> relPartsStack = new System.Collections.Generic.Stack<string>();
 
                 var edgesPath = fGraph.GetPath(target);
                 foreach (Edge edge in edgesPath) {
@@ -137,7 +139,7 @@ namespace GKCore.Kinships
                         degree += deg;
 
                         if (finRel == RelationKind.rkUndefined && fullFormat) {
-                            part = GetRelationPart(starting, src, prevRel, great, degree, shortForm);
+                            relPart = GetRelationPart(starting, src, prevRel, great, degree, shortForm);
                             src = prev_tgt;
 
                             starting = prev_tgt;
@@ -145,8 +147,7 @@ namespace GKCore.Kinships
                             degree = 0;
                             prevRel = RelationKind.rkNone;
 
-                            if (fullRel.Length > 0) fullRel += ", ";
-                            fullRel += part;
+                            relPartsStack.Push(relPart);
 
                             finRel = KinshipsMan.FindKinship(prevRel, curRel, out g, out deg);
                             great += g;
@@ -161,10 +162,17 @@ namespace GKCore.Kinships
                     string relRes = GetRelationName(targetRec, finRel, great, degree, shortForm);
                     return relRes;
                 } else {
-                    part = GetRelationPart(starting, tgt, finRel, great, degree, shortForm);
+                    relPart = GetRelationPart(starting, tgt, finRel, great, degree, shortForm);
 
-                    if (fullRel.Length > 0) fullRel += ", ";
-                    fullRel += part;
+                    relPartsStack.Push(relPart);
+
+                    string fullRel = "";
+                    while (relPartsStack.Count > 0){
+                        fullRel += relPartsStack.Pop();
+                        if (relPartsStack.Count != 0) {
+                            fullRel += ", ";
+                        }
+                    }
 
                     return fullRel;
                 }


### PR DESCRIPTION
Assume user selected 2 persons:
Person 1
Person 2

Now order of output is more natural:
Person1 is somebody for PersonA, PersonA is somebody  for personB, PersonB is somebody for Person2.