### PR TITLE
Add methods to increment / decrement GDMDate

### DIFF
--- a/projects/GKTests/GDModel/GDMDateTests.cs
+++ b/projects/GKTests/GDModel/GDMDateTests.cs
@@ -737,8 +737,46 @@ namespace GDModel
             Assert.AreEqual("20 DEC 1980", GDMDate.CreateByFormattedStr("20/12/1980", false).StringValue);
             Assert.AreEqual("DEC 1980", GDMDate.CreateByFormattedStr("__/12/1980", false).StringValue);
             Assert.AreEqual(null, GDMDate.CreateByFormattedStr("1980", false));
-            
+
             Assert.Throws(typeof(GDMDateException), () => { GDMDate.CreateByFormattedStr("1980", true); });
+        }
+
+        [Test]
+        [TestCase("", "")]
+        [TestCase("2024", "2025")]
+        [TestCase("001B.C.", "001")]
+        [TestCase("OCT 2024", "NOV 2024")]
+        [TestCase("DEC 2024", "JAN 2025")]
+        [TestCase("01 OCT 2024", "02 OCT 2024")]
+        [TestCase("31 OCT 2024", "01 NOV 2024")]
+        [TestCase("31 DEC 2024", "01 JAN 2025")]
+        [TestCase("28 FEB 1900", "01 MAR 1900")]
+        [TestCase("28 FEB 2000", "29 FEB 2000")]
+        [TestCase("29 FEB 2000", "01 MAR 2000")]
+        [TestCase("28 FEB 2023", "01 MAR 2023")]
+        [TestCase("28 FEB 2024", "29 FEB 2024")]
+        [TestCase("29 FEB 2024", "01 MAR 2024")]
+        [TestCase("28 FEB 001B.C.", "29 FEB 001B.C.")]
+        [TestCase("29 FEB 001B.C.", "01 MAR 001B.C.")]
+        [TestCase("28 FEB 005B.C.", "29 FEB 005B.C.")]
+        [TestCase("29 FEB 005B.C.", "01 MAR 005B.C.")]
+        [TestCase("28 FEB 097B.C.", "29 FEB 097B.C.")]
+        [TestCase("29 FEB 097B.C.", "01 MAR 097B.C.")]
+        [TestCase("28 FEB 101B.C.", "01 MAR 101B.C.")]
+        [TestCase("@#DJULIAN@ 29 FEB 2024", "@#DJULIAN@ 01 MAR 2024")]
+        [TestCase("@#DJULIAN@ 28 FEB 1900", "@#DJULIAN@ 29 FEB 1900")]
+        [TestCase("@#DJULIAN@ 29 FEB 1900", "@#DJULIAN@ 01 MAR 1900")]
+        [TestCase("@#DJULIAN@ 28 FEB 2000", "@#DJULIAN@ 29 FEB 2000")]
+        [TestCase("@#DJULIAN@ 29 FEB 2000", "@#DJULIAN@ 01 MAR 2000")]
+        [TestCase("@#DJULIAN@ 28 FEB 2023", "@#DJULIAN@ 01 MAR 2023")]
+        [TestCase("@#DJULIAN@ 29 FEB 2024", "@#DJULIAN@ 01 MAR 2024")]
+        public void Test_Increment_Decrement(string value, string expected)
+        {
+            var d = new GDMDate();
+            d.StringValue = value;
+            Assert.AreEqual(expected, GDMDate.Increment(d).StringValue);
+            d.StringValue = expected;
+            Assert.AreEqual(value, GDMDate.Decrement(d).StringValue);
         }
     }
 }


### PR DESCRIPTION
The functions support to increase/decrease the dates by 1 of the smallest available period for the date. Invalid partial dates (eg. only month-year or day-year set are not supported and likely throw an error).

`DaysInMonth` supports only Proleptic Julian/Gregorian calendars. Therefore it completely ignores the leap year problem that existed between 45BC and 8AD.

I need this functions to be able to calculate difference in the time periods.