### PR TITLE
Set C# version to 7.3

### DIFF
--- a/projects/GKConfigurations.targets
+++ b/projects/GKConfigurations.targets
@@ -2,7 +2,7 @@
   <!-- Common -->
   <PropertyGroup>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
-    <LangVersion>5</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>


### PR DESCRIPTION
This is the last pre- .NET Core version. C# 5 is too old (released 12 years ago in 2012).