### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 Eto.xml
 *.log
 *.user
+.DS_Store
 
 gource-gk.cmd
 NUnitResults.xml
@@ -30,3 +31,4 @@ GEDKeeper2Lux.sln
 
 /projects/GKv2/packages/**/
 /projects/GKv3/packages/**/
+


### PR DESCRIPTION
.DS_Store is a special file MacOS creates when folder settings are changed.
In reality it happens every time the folder is accessed via Finder.
