### PR TITLE
[GKv3/Mac] Fix saving settings on exit

### DIFF
--- a/projects/GKCore/GKCore/AppHost.cs
+++ b/projects/GKCore/GKCore/AppHost.cs
@@ -114,6 +114,7 @@ namespace GKCore
         protected virtual void ApplicationExit()
         {
             AppHost.Instance.SaveLastBases();
+            AppHost.DoneSettings();
         }
 
         private void AutosaveTimer_Tick(object sender, EventArgs e)

--- a/projects/GKv3/GEDKeeper3/GKProgram.cs
+++ b/projects/GKv3/GEDKeeper3/GKProgram.cs
@@ -66,14 +66,10 @@ namespace GEDKeeper3
             using (var tracker = new SingleInstanceTracker(GKData.APP_TITLE, AppHost.GetSingleInstanceEnforcer)) {
                 if (tracker.IsFirstInstance) {
                     AppHost.InitSettings();
-                    try {
-                        var appHost = (EtoAppHost)AppHost.Instance;
-                        appHost.Init(args, false);
+                    var appHost = (EtoAppHost)AppHost.Instance;
+                    appHost.Init(args, false);
 
-                        application.Run();
-                    } finally {
-                        AppHost.DoneSettings();
-                    }
+                    application.Run();
                 } else {
                     tracker.SendMessageToFirstInstance(args);
                 }


### PR DESCRIPTION
Fixes following issues:

_@cbettinger in #507:_
> The second thing to mention, is that all settings (e.g. the selected language) seem to be lost on a second start of the application.

_@gasparschott in #618:_
> On startup, GEDKeeper always asks to select language.
On startup, the last opened project is not restored. In Options > Common, "Load recently opened files at startup" is disabled and cannot be checked.
On startup, the last opened window size is not restored, either for new projects or when opening a previously saved file.
From these behaviors it seems that app preferences are not being saved or read. ~/.config/GEDKeeper3/GEDKeeper2.ini