### PR TITLE
[GKv3/Mac] Fix finding bin path

### DIFF
--- a/projects/GKCore/GKCore.nstd.csproj
+++ b/projects/GKCore/GKCore.nstd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <AssemblyName>GKCore</AssemblyName>
         <RootNamespace />
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/projects/GKCore/GKCore/GKUtils.cs
+++ b/projects/GKCore/GKCore/GKUtils.cs
@@ -1945,9 +1945,13 @@ namespace GKCore
 
         public static string GetBinPath()
         {
+#if NET6_0_OR_GREATER
+            string fn = Environment.ProcessPath;
+#else
             var asm = SysUtils.GetExecutingAssembly();
             Module[] mods = asm.GetModules();
             string fn = mods[0].FullyQualifiedName;
+#endif
             return Path.GetDirectoryName(fn) + Path.DirectorySeparatorChar;
         }
 

--- a/projects/GKCore/GKCore/HashCode.cs
+++ b/projects/GKCore/GKCore/HashCode.cs
@@ -1,3 +1,5 @@
+#if !NETSTANDARD2_1_OR_GREATER && !NETCOREAPP2_1_OR_GREATER
+
 /*
   The xxHash32 implementation is based on the code published by Yann Collet:
   https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b39696afea1/xxhash.c
@@ -221,3 +223,4 @@ namespace System
         }
     }
 }
+#endif


### PR DESCRIPTION
The old method was returing null, because on MacOS the whole program is compiled into one native binary that does not have "assemblies".

Since .NET 6 there is Environment.ProcessPath, which is the most reliable way to get the executing file.

This is the cause of the following issue from @cbettinger in #507:

> The first thing to mention, is that the list of languages to select from seems to be empty. Actually I think it has exactly one invisible entry (English), because the dialog can be closed using the Accept button and the UI then displays English labels.