### PR TITLE
[GKv3/Mac] Do not include system menu items

### DIFF
--- a/projects/GKv3/GEDKeeper3/GKUI/Forms/BaseWinSDI.xeto
+++ b/projects/GKv3/GEDKeeper3/GKUI/Forms/BaseWinSDI.xeto
@@ -53,7 +53,7 @@
   </Form.ToolBar>
 
   <Form.Menu>
-    <MenuBar>
+    <MenuBar IncludeSystemItems="None">
 
       <ButtonMenuItem x:Name="miFile">
         <ButtonMenuItem x:Name="miFileNew" Shortcut="CommonModifier+N" Image="{Resource Resources.btn_create_new.gif, GKCore}" Click="miFileNew_Click" />


### PR DESCRIPTION
This fixes following issue by @gasparschott in #618
> UI: MacOS "File", "Edit", "Window", and "Help" default menus are not removed; i.e., these menu items are duplicated in the menu bar, after GEDKeeper's own menu items.

The menu would not look exactly canonical on Mac, but we could deal with this later. 
