### PR TITLE
Downgrade System.IO.Packaging to 8.0.1

### DIFF
--- a/projects/GKCore/GKCore.nstd.csproj
+++ b/projects/GKCore/GKCore.nstd.csproj
@@ -56,7 +56,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="iTextSharp.LGPLv2.Core" Version="3.4.18" />
         <PackageReference Include="log4net" Version="3.0.3" />
-        <PackageReference Include="System.IO.Packaging" Version="9.0.6" />
+        <PackageReference Include="System.IO.Packaging" Version="8.0.1" />
     </ItemGroup>
 
 


### PR DESCRIPTION
9.0.6 shows a warning:

> Warning  : System.IO.Packaging 9.0.6 doesn't support net6.0 and has not been tested with it. Consider upgrading your TargetFramework to net8.0 or later. You may also set `<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>` in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk.
