### PR TITLE
[GKv3/Mac] Fix menu items

### DIFF
--- a/projects/GKv3/GEDKeeper3/GKUI/Forms/BaseWinSDI.xeto
+++ b/projects/GKv3/GEDKeeper3/GKUI/Forms/BaseWinSDI.xeto
@@ -52,9 +52,9 @@
   </Form.ToolBar>
 
   <Form.Menu>
-    <complat:GKMenuBar IncludeSystemItems="None">
+    <complat:GKMenuBar>
 
-      <ButtonMenuItem x:Name="miFile">
+      <ButtonMenuItem x:Name="miFile" Text="&amp;File">
         <ButtonMenuItem x:Name="miFileNew" Shortcut="CommonModifier+N" Image="{Resource Resources.btn_create_new.gif, GKCore}" Click="miFileNew_Click" />
         <ButtonMenuItem x:Name="miFileLoad" Shortcut="CommonModifier+O" Image="{Resource Resources.btn_load.gif, GKCore}" Click="miFileLoad_Click" />
         <ButtonMenuItem x:Name="miMRUFiles" Enabled="False" />
@@ -68,11 +68,9 @@
           <ButtonMenuItem x:Name="miExportTable" Image="{Resource Resources.btn_excel.gif, GKCore}" Click="miExportTable_Click" />
           <ButtonMenuItem x:Name="miExportToStrictGEDCOM" Click="miExportToStrictGEDCOM_Click" />
         </ButtonMenuItem>
-        <SeparatorMenuItem />
-        <ButtonMenuItem x:Name="miExit" Shortcut="CommonModifier+X" Image="{Resource Resources.btn_exit.gif, GKCore}" Click="miExit_Click" />
       </ButtonMenuItem>
 
-      <ButtonMenuItem x:Name="miEdit">
+      <ButtonMenuItem x:Name="miEdit" Text="&amp;Edit">
         <ButtonMenuItem x:Name="miRecordAdd" Shortcut="CommonModifier+I" Image="{Resource Resources.btn_rec_new.gif, GKCore}" Click="miRecordAdd_Click" />
         <ButtonMenuItem x:Name="miRecordEdit" Shortcut="CommonModifier+Enter" Image="{Resource Resources.btn_rec_edit.gif, GKCore}" Click="miRecordEdit_Click" />
         <ButtonMenuItem x:Name="miRecordDelete" Shortcut="CommonModifier+L" Image="{Resource Resources.btn_rec_delete.gif, GKCore}" Click="miRecordDelete_Click" />
@@ -128,21 +126,27 @@
 
       <ButtonMenuItem x:Name="miPlugins" />
 
-      <ButtonMenuItem x:Name="miWindow">
+      <ButtonMenuItem x:Name="miWindow" Text="&amp;Window">
         <ButtonMenuItem x:Name="miWinCascade" Click="miWinCascade_Click" />
         <ButtonMenuItem x:Name="miWinHTile" Click="miWinHTile_Click" />
         <ButtonMenuItem x:Name="miWinVTile" Click="miWinVTile_Click" />
         <ButtonMenuItem x:Name="miWinMinimize" Click="miWinMinimize_Click" />
       </ButtonMenuItem>
 
-      <ButtonMenuItem x:Name="miHelp">
+      <ButtonMenuItem x:Name="miHelp" Text="&amp;Help">
         <ButtonMenuItem x:Name="miContext" Shortcut="F1" Image="{Resource Resources.btn_help.gif, GKCore}" Click="miContext_Click" />
         <SeparatorMenuItem />
         <ButtonMenuItem x:Name="miLogSend" Click="miLogSend_Click" />
         <ButtonMenuItem x:Name="miLogView" Click="miLogView_Click" />
-        <SeparatorMenuItem />
-        <ButtonMenuItem x:Name="miAbout" Image="{Resource Resources.btn_scroll.gif, GKCore}" Click="miAbout_Click" />
       </ButtonMenuItem>
+
+      <GKMenuBar.QuitItem>
+        <ButtonMenuItem x:Name="miExit" Shortcut="CommonModifier+X" Image="{Resource Resources.btn_exit.gif, GKCore}" Click="miExit_Click" />
+      </GKMenuBar.QuitItem>
+
+      <GKMenuBar.AboutItem>
+        <ButtonMenuItem x:Name="miAbout" Image="{Resource Resources.btn_scroll.gif, GKCore}" Click="miAbout_Click" />
+			</GKMenuBar.AboutItem>
 
     </complat:GKMenuBar>
   </Form.Menu>


### PR DESCRIPTION
**Problem**: copy, paste, select all, etc commands do not work in text boxes on mac. Apparently this is because these functions work via built-in menu items (see https://github.com/picoe/Eto/issues/1323).

Side quest: `IncludeSystemItems` was disabled previously because otherwise the menu items were duplicated. Solution for this is to name menu items in a particular way so the Eto.Forms could find them: https://github.com/picoe/Eto/blob/7240ff6fff6ecb836498d5923944e0c6381e5462/src/Eto.Mac/Forms/Menu/MenuBarHandler.cs#L149C33-L149C80. Hence, I had to add `Text=` attributes to the File, Edit, Windows, Help menus with the particular text that Eto forms expect (it does not make any difference after the form is loaded as translations are re-applied after).

Also moved about and exit items into dedicated places so they are displayed where MacOS expect them.